### PR TITLE
feat: Add in-context translation to react installation.mdx

### DIFF
--- a/docs/web/using_with_react/installation.mdx
+++ b/docs/web/using_with_react/installation.mdx
@@ -8,7 +8,6 @@ slug: /web/using_with_react/installation
 To get full image of working React integration check our [React example application](https://github.com/tolgee/react-example).
 To install Tolgee React integration library run:
 
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -35,10 +34,36 @@ yarn add @tolgee/react
 </TabItem>
 </Tabs>
 
-First, you will need to wrap your application with [`TolgeeProvider`](./api#tolgeeprovider) component.
+To install UI bundle for in-context translating you will also need to install package `@tolgee/ui`.
+
+<Tabs
+    defaultValue="npm"
+    values={[
+        {label: 'npm', value: 'npm',},
+        {label: 'yarn', value: 'yarn'},
+    ]
+    }>
+<TabItem value="npm">
+
+```shell
+npm install @tolgee/ui
+```
+
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn add @tolgee/ui
+```
+
+</TabItem>
+</Tabs>
+
+Then, you will need to wrap your application with [`TolgeeProvider`](./api#tolgeeprovider) component.
 
 ```javascript
 import {TolgeeProvider} from "@tolgee/react";
+import { UI } from '@tolgee/ui';
 
 ...
 
@@ -46,6 +71,7 @@ import {TolgeeProvider} from "@tolgee/react";
     filesUrlPrefix="i18n/"
     apiUrl={process.env.REACT_APP_TOLGEE_API_URL}
     apiKey={process.env.REACT_APP_TOLGEE_API_KEY}
+    ui={process.env.REACT_APP_TOLGEE_API_KEY ? UI : undefined} //only required if you want use in-context translation
     loadingFallback={<>Loading...</>} //content to show when localization data is loading
 >
     <Your app components>
@@ -58,8 +84,10 @@ If you bootstrapped your application with Create React App, your `.env.developme
 REACT_APP_TOLGEE_API_URL=https://app.tolgee.io
 REACT_APP_TOLGEE_API_KEY=bkcq7tkoinjg9ehk9hc4t3duq3
 ```
+
 Otherwise, you can set the properties directly, or you can use plugins like [dotenv-webpack plugin](https://www.npmjs.com/package/dotenv-webpack).
 
 ## Other configuration properties
+
 Configuration properties for all web integrations are similar. They are described in [configuration](../configuration)
 section.


### PR DESCRIPTION
The installation guide for Angular also describes the in-context translation, which is missing from the installation guide for React. 