### PR TITLE
Add reference to S3 Service Endpoints

### DIFF
--- a/docs/platform/self_hosting/configuration.mdx
+++ b/docs/platform/self_hosting/configuration.mdx
@@ -59,7 +59,7 @@ the S3 server rather than on disk. (default: `false`)
 When enabled, you will need to set the following configuration properties as well:
  - s3.access-key
  - s3.secret-key
- - s3.endpoint
+ - s3.endpoint (has to be set to a service endpoint: https://docs.aws.amazon.com/general/latest/gr/s3.html)
  - s3.signing-region
  - s3.bucket-name
 


### PR DESCRIPTION
right now it is tricky to find out what the s3.endpoint is supposed to mean - perhaps at least add a note to the aws service endpoints as all other providers will instruct how to set those when creating the bucket