### PR TITLE
feat: document application.properties

### DIFF
--- a/docs/platform/self_hosting/running_with_java.mdx
+++ b/docs/platform/self_hosting/running_with_java.mdx
@@ -6,14 +6,15 @@ slug: /platform/self_hosting/running_with_java
 description: "Learn how to self-host Tolgee with Java. To run Tolgee server using Java download the latest release from github."
 ---
 
-To run Tolgee server using Java download the latest release from
-[github](https://github.com/tolgee/server/releases).
-
-To run Tolgee like this, Docker has to be installed on your machine.
+To run Tolgee server using Java, download the latest release from [GitHub](https://github.com/tolgee/tolgee-platform/releases).
 
 :::info
 Since v2, Tolgee tries to run PostgreSQL container by default.
-To disable this, set `tolgee.postgres-autostart.enabled` property to `false` and provide Postgres configuration yourself.
+To disable this, set `tolgee.postgres-autostart.enabled` property to `false` and provide
+the [data source settings](configuration#data-source-settings) yourself.
+
+Disabling this is **required** if you wish to run Tolgee without having Docker installed on your machine. If you leave
+it enabled, Docker is required to run Tolgee.
 :::
 
 Then you can run it with:
@@ -26,3 +27,8 @@ By default, server is exposed on port 8080. To change this you can set `server.p
 java -jar tolgee-<version>.jar --server.port=80
 ```
 See [configuration](configuration) page for other configuration options.
+
+:::tip
+You can specify your configuration in an `application.properties` file, next to the Tolgee server jar. The configuration
+will be automatically loaded from it, which is more convenient than specifying everything as part of the run command.
+:::


### PR DESCRIPTION
Also clarifies when Docker is required, and gives instructions on what to do in order to run Tolgee on bare-metal without Docker installed.