### PR TITLE
fix: typo in `using_with_react` page

### DIFF
--- a/js-sdk_versioned_docs/version-4.x.x/using_with_react/api.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_react/api.mdx
@@ -47,7 +47,7 @@ import { T } from '@tolgee/react';
  - `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
 
 #### Children `defaultValue?` | `keyName?`
-`String` - If `keyName` property is not defined, child is taken as `keyName`. I it is present child can be used as `defaultValue`.
+`String` - If `keyName` property is not defined, child is taken as `keyName`. If it is present child can be used as `defaultValue`.
 
 ## Hook `useTranslate`
 


### PR DESCRIPTION
This PR fixes a typo in the docs under the `using_with_react` page.
```diff
-I it is present...
+If it is present...
```