### PR TITLE
fix: Link to Chrome plugin on What is Tolgee

### DIFF
--- a/platform/what_is_tolgee.mdx
+++ b/platform/what_is_tolgee.mdx
@@ -64,7 +64,7 @@ No! You can do that automatically in the CI/CD pipeline when your App is built. 
 
 ## My mama speaks Spanish. Can she translate the strings when my App is deployed?
 
-Yes! She can use (the Tolgee Tools Chrome plugin)[https://chrome.google.com/webstore/detail/tolgee-tools/hacnbapajkkfohnonhbmegojnddagfnj] to enable the dev tools also in deployed App. Then she can translate it directly in the App.
+Yes! She can use [the Tolgee Tools Chrome plugin](https://chrome.google.com/webstore/detail/tolgee-tools/hacnbapajkkfohnonhbmegojnddagfnj) to enable the dev tools also in deployed App. Then she can translate it directly in the App.
 
 ## What frameworks are supported?
 


### PR DESCRIPTION
This PR fixes incorrect Markdown format of link to the Chrome plugin on the `What is Tolgee` page.