### PR TITLE
fix: Add Figma plugin and Translation Memory management to roadmap

### DIFF
--- a/src/pages/roadmap/index.tsx
+++ b/src/pages/roadmap/index.tsx
@@ -26,6 +26,18 @@ const roadmapData = {
     future: true,
     items: [
       {
+        name: 'Figma plugin',
+        gitHubIssueLink:
+          'https://github.com/tolgee/tolgee-platform/issues/1385',
+        description: (
+          <p>
+            Figma plugin is our first integration with a design tools. This will
+            help developers and localization managers to simply import and
+            export keys directly in Figma.
+          </p>
+        ),
+      },
+      {
         name: 'Permission enhancements',
         gitHubIssueLink:
           'https://github.com/tolgee/tolgee-platform/issues/1336',
@@ -244,10 +256,9 @@ const roadmapData = {
           'https://github.com/tolgee/tolgee-platform/issues/1560',
         description: (
           <p>
-            With Tolgee, developers and translators can translate apps very
-            easily. We would also like to provide translators with simplicity by
-            enabling them to translate texts directly in tools like{' '}
-            <b>Figma, XD, or Miro</b>.
+            After the Figma plugin, we would also like to provide developers and
+            localization managers plugins for more design tools like{' '}
+            <b>Adobe XD or Sketch</b>.
           </p>
         ),
       },

--- a/src/pages/roadmap/index.tsx
+++ b/src/pages/roadmap/index.tsx
@@ -228,6 +228,18 @@ const roadmapData = {
         ),
       },
       {
+        name: 'Translation Memory management',
+        gitHubIssueLink:
+          'https://github.com/tolgee/tolgee-platform/issues/1569',
+        description: (
+          <p>
+            Management of Translation Memories will to share them between
+            different projects. You will be also able to import and export TMX
+            files, so you can back-up them if you want.
+          </p>
+        ),
+      },
+      {
         name: 'Ordering professional translation',
         gitHubIssueLink:
           'https://github.com/tolgee/tolgee-platform/issues/1561',


### PR DESCRIPTION
Add Figma plugin to roadmap as a separate feature and also add Translation Memory management to the roadmap.