### PR TITLE
fix: Homepage unnecessary scrollbar

### DIFF
--- a/src/component/home/Intro.tsx
+++ b/src/component/home/Intro.tsx
@@ -126,7 +126,7 @@ export const Intro = () => {
             transform: isLarge ? 'translateY(-50%)' : undefined,
           }}
         >
-          <section className="flex justify-center w-[100vw]">
+          <section className="flex justify-center">
             {Boolean(viewPortHeight) && (
               <div className="flex gap-12 sm:m-12 m-8 flex-col lg:flex-row md:max-w-[1500px] flex-grow">
                 <ImageColumn>


### PR DESCRIPTION
When I view [the homepage](https://tolgee.io/), I see a scrollbar because the "The revolution is here" component is too wide to fit on my screen. I have fixed this by removing the `w-[100vw]` Tailwind rule on this component.

I encountered this behavior on Windows 10 and 11, Firefox and Chrome, 24" 1920x1080 and 14" 2880x1800 (with 200% DPI scaling).