### PR TITLE
feat: Update Figma plugin link and one minor CSS update

### DIFF
--- a/src/component/pageComponents/featurePage/translationAssistance/MachineTranslationFeature.tsx
+++ b/src/component/pageComponents/featurePage/translationAssistance/MachineTranslationFeature.tsx
@@ -41,7 +41,7 @@ function MtCreditsSlider() {
       />
       <div className="">{totalPrice.toLocaleString('en-US')} €</div>
 
-      <div className="line-through text-xs dark:text-gray-300 text-gray-500 mt-[-10px] min-h-[17px]">
+      <div className="line-through text-xs dark:text-gray-300 text-gray-500 min-h-[17px]">
         {regularPrice && <>{regularPrice.toLocaleString('en-US')} €</>}
       </div>
     </div>

--- a/src/integrations.tsx
+++ b/src/integrations.tsx
@@ -69,7 +69,7 @@ export const integrations = [
     logo: '/img/technologies/logo-figma.svg',
     links: {
       'Landing Page': '/integrations/figma',
-      Docs: '/platform/figma-plugin/usage',
+      Docs: '/platform/figma-plugin/setup',
       'GitHub Repository': 'https://github.com/tolgee/figma-plugin',
     },
   },


### PR DESCRIPTION
This PR updates the link to Figma docs on the All Integrations page as it makes more sense to link to the "Setup" article rather than the "Usage" article.

Also, I have removed the negative margin-top from the crossed-out price in the Machine Translations credits component:

### Before
![before](https://user-images.githubusercontent.com/10096404/226630948-89c517e0-8785-458d-8a54-72a509cfcf5c.png)

### After
![after](https://user-images.githubusercontent.com/10096404/226630976-cb5d991e-a373-4f31-8761-13ad527ed96e.png)
