### PR TITLE
feat: typed translation keys docs

### DIFF
--- a/js-sdk/typed_keys.mdx
+++ b/js-sdk/typed_keys.mdx
@@ -1,5 +1,5 @@
 ---
-id: typescript
+id: typed_keys
 title: Typed translation keys
 description: 'Adding type definitions to the translation keys.'
 ---

--- a/js-sdk/typescript.mdx
+++ b/js-sdk/typescript.mdx
@@ -1,0 +1,40 @@
+---
+id: typescript
+title: Typed translation keys
+description: 'Adding type definitions to the translation keys.'
+---
+
+If you want your keys to be typed with TypeScript you can do with the following `tolgee.d.ts` file:
+
+```ts
+// tolgee.d.ts
+
+import type en from './i18n/en.json';
+
+declare module '@tolgee/core/lib/types' {
+  type TranslationsType = typeof en;
+
+  // ensures that nested keys are accessible with "."
+  type DotNotationEntries<T> = T extends object
+    ? {
+        [K in keyof T]: `${K & string}${T[K] extends undefined
+          ? ''
+          : T[K] extends object
+          ? `.${DotNotationEntries<T[K]>}`
+          : ''}`;
+      }[keyof T]
+    : '';
+
+  // enables both intellisense and new keys without an error
+  type LiteralUnion<LiteralType extends BaseType, BaseType extends Primitive> =
+    | LiteralType
+    | (BaseType & { _?: never });
+
+  export type TranslationKey = LiteralUnion<
+    DotNotationEntries<TranslationsType>,
+    string
+  >;
+}
+```
+
+This setup will give you TypeScript intellisense for existing keys but also allows you to add non-existing keys. If you intentionally want TypeScript errors for non-existing keys, just remove `LiteralUnion`.

--- a/sidebarJsSdk.js
+++ b/sidebarJsSdk.js
@@ -85,7 +85,7 @@ module.exports = {
       type: 'doc',
     },
     {
-      id: 'typescript',
+      id: 'typed_keys',
       type: 'doc',
     },
     {

--- a/sidebarJsSdk.js
+++ b/sidebarJsSdk.js
@@ -85,6 +85,10 @@ module.exports = {
       type: 'doc',
     },
     {
+      id: 'typescript',
+      type: 'doc',
+    },
+    {
       id: 'usage_without_platform',
       type: 'doc',
     },


### PR DESCRIPTION
https://github.com/tolgee/tolgee-js/pull/3186

Full blown ts errors are not very practical in dev mode, but there is a way how to use this only for intellisense but not for error checking, which I think will be more convenient. So I've put that into docs as well.