### PR TITLE
feat: CLI docs update and fix internal links

### DIFF
--- a/blog/2022-01-20-super-fast-react-localizaton-with-i18next-and-tolgee.md
+++ b/blog/2022-01-20-super-fast-react-localizaton-with-i18next-and-tolgee.md
@@ -144,7 +144,7 @@ withTolgee(i18n, {
 ```
 
 This sets Tolgee as translation provider for i18next and enables
-[ICU message formatter](/platform/icu_message_format). Change
+[ICU message formatter](/platform/translation_process/icu_message_format). Change
 `supportedLngs` to language tags you created while creating project in Tolgee localization platform.
 
 Then wrap your `<App/>` component with `Suspens` component.

--- a/blog/2022-07-29-tolgee-with-vanilla-static-html-js-app.md
+++ b/blog/2022-07-29-tolgee-with-vanilla-static-html-js-app.md
@@ -167,7 +167,7 @@ The code above shows how to initialize Tolgee with the provided configuration ob
 
 |apiUrl|The URL of the api where we are saving data.|
 |:------|:--------------------------------------------|
-|apiKey|Which you can obtain in the [app](https://app.tolgee.io) or in your self-hosted app by following this [documentation page](/platform/api-keys-and-pat-tokens)|
+|apiKey|Which you can obtain in the [app](https://app.tolgee.io) or in your self-hosted app by following this [documentation page](/platform/account_settings/api_keys_and_pat_tokens)|
 |inputPrefix|Character sequence that appears before each translation|
 |inputSuffix|Character sequence that appears after each translation|
 |watch|parameter that tells Tolgee whether or not to watch for changes in the DOM and update translations.|

--- a/blog/2022-08-27-new-api-keys-and-pats.md
+++ b/blog/2022-08-27-new-api-keys-and-pats.md
@@ -29,7 +29,7 @@ you delete them.
   a secret.
 
 To learn more about,
-visit [Project API keys and Pats documentation section](/platform/api-keys-and-pat-tokens).
+visit [Project API keys and Pats documentation section](/platform/account_settings/api_keys_and_pat_tokens).
 
 ## Why we did do it?
 

--- a/blog/2022-11-04-dont-create-your-own-i18n-library.md
+++ b/blog/2022-11-04-dont-create-your-own-i18n-library.md
@@ -144,7 +144,7 @@ added similar if statements in each occurrence, and everything works fine. Now y
 Arabic. Gotcha! Since all your plurals are defined in the code, you'll have a very tough time finding all the plurals in
 your code and adding Arabic forms.
 
-Luckily, there's an easier way how to handle plurals. [ICU Message Format 🙌](https://tolgee.io/platform/icu_message_format)!
+Luckily, there's an easier way how to handle plurals. [ICU Message Format 🙌](https://tolgee.io/platform/translation_process/icu_message_format)!
 With ICU message format, you can define translations like this:
 
 ```

--- a/blog/2022-12-6-benefits-challenges-localization.md
+++ b/blog/2022-12-6-benefits-challenges-localization.md
@@ -70,7 +70,7 @@ First, Tolgee can offer context in the form of automatic screenshots to provide 
 
 To make your software usable for customers in different regions, it’s not enough to simply translate the text. You must also account for formatting differences and conventions for writing dates, times, numbers, addresses, and currency. Hard-coded date, time, or currency formats will cause trouble during the localization process, as languages and countries use different date and time formats. 
 
-Tolgee deals with formatting issues using the [ICU (International Components for Unicode)](/platform/icu_message_format) message format. ICU also provides a lot of other helpful functionalities, such as advanced pluralization or selection rules. 
+Tolgee deals with formatting issues using the [ICU (International Components for Unicode)](/platform/translation_process/icu_message_format) message format. ICU also provides a lot of other helpful functionalities, such as advanced pluralization or selection rules. 
 
 
 ## 6. Inconsistency of translation

--- a/blog/2023-03-17-figma-plugin.md
+++ b/blog/2023-03-17-figma-plugin.md
@@ -37,10 +37,10 @@ Getting started with Tolgee’s Figma plugin is easy. Here’s how:
 
 1. Sign up for Tolgee: If you haven’t already, [sign up for Tolgee](https://app.tolgee.io/sign_up).
 2. [Install Tolgee’s Figma plugin](https://www.figma.com/community/plugin/1212381421658754793/Tolgee).
-3. [Connect your Figma project to Tolgee](/platform/figma-plugin/setup#setup) and start managing your localization process seamlessly.
+3. [Connect your Figma project to Tolgee](/platform/integrations/figma_plugin/setup#setup) and start managing your localization process seamlessly.
 
 
 ## Conclusion
 With Tolgee’s Figma plugin, the localization team can save time, simplify collaboration, and reduce errors in their localization process. We’re thrilled to offer this integration to our customers, and we’re excited to see how it simplifies your localization process!
 
-For more information, you can visit the [plugin documentation](/platform/figma-plugin/setup) and the [GitHub repository](https://github.com/tolgee/figma-plugin).
+For more information, you can visit the [plugin documentation](/platform/integrations/figma_plugin/setup) and the [GitHub repository](https://github.com/tolgee/figma-plugin).

--- a/js-sdk/api/core_package/format_simple.mdx
+++ b/js-sdk/api/core_package/format_simple.mdx
@@ -43,4 +43,4 @@ f("This will work 'as expected'");
 ```
 
 That's it! We've tried to do this format as simple as possible so the parser doesn't bloat your bundle.
-If you need advanced features use [`@tolgee/format-icu`](/platform/icu_message_format) package.
+If you need advanced features use [`@tolgee/format-icu`](/platform/translation_process/icu_message_format) package.

--- a/js-sdk/api/packages.mdx
+++ b/js-sdk/api/packages.mdx
@@ -29,4 +29,4 @@ Provide framework/library specific wrappers around `Tolgee`.
 
 ### @tolgee/format-icu
 
-Provides plugin for [Icu message format](/platform/icu_message_format).
+Provides plugin for [Icu message format](/platform/translation_process/icu_message_format).

--- a/js-sdk/formatting.mdx
+++ b/js-sdk/formatting.mdx
@@ -20,7 +20,7 @@ tolgee.use(FormatSimple());
 
 For advanced formatting functionality install `FormatIcu` plugin, which is shipped in separate package.
 
-import {InstallationTabs} from "../src/component/InstallationTabs";
+import { InstallationTabs } from '../src/component/InstallationTabs';
 
 <InstallationTabs lib="@tolgee/format-icu" />
 
@@ -32,4 +32,4 @@ import { FormatIcu } from '@tolgee/format-icu';
 tolgee.use(FormatIcu());
 ```
 
-Read more about [ICU message format](/platform/icu_message_format)
+Read more about [ICU message format](/platform/translation_process/icu_message_format)

--- a/js-sdk/in_context.mdx
+++ b/js-sdk/in_context.mdx
@@ -5,7 +5,7 @@ slug: in-context
 description: 'Learn how to use in-context translating feature in Tolgee tool and how to enable in-context translating on production.'
 ---
 
-For local development, supply `apiUrl`, `apiKey` options (see [Integration](/platform/integration)) and [`DevTools`](./api/web_package/tools#devtools) plugin. If you set everything properly, you can use in-context translating:
+For local development, supply `apiUrl`, `apiKey` options (see [Integration](/platform/integrations/about_integrations)) and [`DevTools`](./api/web_package/tools#devtools) plugin. If you set everything properly, you can use in-context translating:
 
 1.  Press and hold `Alt`/`Option` key
 2.  Navigate mouse over any translation on your website
@@ -80,4 +80,4 @@ if (shouldIncludeInContextTools) {
 
 #### Using parts of InContextTools functionality
 
-[`InContextTools`](/api/web_package/tools.mdx#incontexttools) (or `DevTools` in development) are  a combination of multiple plugins, which you can include independently, check [`InContextTools`](/api/web_package/tools.mdx#incontexttools) documentation for more info.
+[`InContextTools`](/api/web_package/tools.mdx#incontexttools) (or `DevTools` in development) are a combination of multiple plugins, which you can include independently, check [`InContextTools`](/api/web_package/tools.mdx#incontexttools) documentation for more info.

--- a/js-sdk/initialization.mdx
+++ b/js-sdk/initialization.mdx
@@ -34,7 +34,7 @@ Never leak your API key! We strongly recommend against adding API key into git r
 
 We use `DevTools` plugin which will provide in-context translating in dev mode. We also need to provide `apiUrl` and `apiKey` for the in-context to work.
 
-> Obtaining Tolgee API key is described in [Integration](/platform/integration) chapter.
+> Obtaining Tolgee API key is described in [Integration](/platform/integrations/about_integrations) chapter.
 
 > Check all [tolgee options](./api/core_package/options) and [tolgee plugins](./api/web_package/plugins).
 

--- a/js-sdk/integrations/react/api.mdx
+++ b/js-sdk/integrations/react/api.mdx
@@ -30,8 +30,8 @@ import { TolgeeProvider } from '@tolgee/react';
   useSuspense?: boolean
 }
 ```
-  - useSuspense: boolean - `TolgeeProvider` and `useTranslate` will use suspense pattern (default: true)
 
+- useSuspense: boolean - `TolgeeProvider` and `useTranslate` will use suspense pattern (default: true)
 
 ## T component
 
@@ -54,7 +54,7 @@ import { T } from '@tolgee/react';
 ### Prop `params?`
 
 `Record<string, string | number | ReactElement | (val) => ReactNode>` - variable parameters, which can be used in translation value
-(read more about [ICU message format](/platform/icu_message_format)).
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 ### Prop `ns?`
 
@@ -138,8 +138,8 @@ const WorksAlsoWithOtherEvents = () => {
 
 ```ts
 function useTolgeeSSR(
-  tolgee: TolgeeInstance, 
-  language?: string, 
+  tolgee: TolgeeInstance,
+  language?: string,
   staticData?: TolgeeStaticData
 ): TolgeeInstance;
 ```

--- a/js-sdk/integrations/react/installation.mdx
+++ b/js-sdk/integrations/react/installation.mdx
@@ -62,9 +62,10 @@ Never leak your API key! You don't want visitors of your site to edit your trans
 
 Otherwise, you can set the properties directly, or you can use plugins like [dotenv-webpack plugin](https://www.npmjs.com/package/dotenv-webpack).
 
-> Obtaining Tolgee API key is described in [Integration](/platform/integration) chapter.
+> Obtaining Tolgee API key is described in [Integration](/platform/integrations/about_integrations) chapter.
 
 ## Preparing for production
-import PreparingForProduction from '../../shared/PreparingForProduction.mdx'
+
+import PreparingForProduction from '../../shared/PreparingForProduction.mdx';
 
 <PreparingForProduction />

--- a/js-sdk/integrations/svelte/api.mdx
+++ b/js-sdk/integrations/svelte/api.mdx
@@ -58,7 +58,7 @@ for this key (in selected language nor base language). If you won't provide this
 ### Prop `params?`
 
 `Record<string, string>` - variable params, which can be used in translation value
-(read more about [ICU message format](/platform/icu_message_format)).
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 ### Prop `ns?`
 

--- a/js-sdk/integrations/svelte/installation.mdx
+++ b/js-sdk/integrations/svelte/installation.mdx
@@ -58,9 +58,10 @@ Never leak your API key! You don't want visitors of your site to edit your trans
 .env files to store your API key. API key is then omitted for production build.
 :::
 
-> Obtaining Tolgee API key is described in [Integration](/platform/integration) chapter.
+> Obtaining Tolgee API key is described in [Integration](/platform/integrations/about_integrations) chapter.
 
 ## Preparing for production
-import PreparingForProduction from '../../shared/PreparingForProduction.mdx'
+
+import PreparingForProduction from '../../shared/PreparingForProduction.mdx';
 
 <PreparingForProduction />

--- a/js-sdk/integrations/vue/api.mdx
+++ b/js-sdk/integrations/vue/api.mdx
@@ -85,7 +85,7 @@ for this key (in selected language nor base language). If you won't provide this
 ### Prop `params?`
 
 `Record<string, string>` - variable params, which can be used in translation value
-(read more about [ICU message format](/platform/icu_message_format)).
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 ### Prop `ns?`
 

--- a/js-sdk/integrations/vue/installation.mdx
+++ b/js-sdk/integrations/vue/installation.mdx
@@ -67,9 +67,10 @@ VUE_APP_TOLGEE_API_KEY=tgpak_gfpwiojtnrztqmtbna3dczjxny2ha3dmnu4tk4tnnjvgc
 
 Otherwise, you can set the properties directly, or you can use plugins like [dotenv-webpack plugin](https://www.npmjs.com/package/dotenv-webpack).
 
-> Obtaining Tolgee API key is described in [Integration](/platform/integration) chapter.
+> Obtaining Tolgee API key is described in [Integration](/platform/integrations/about_integrations) chapter.
 
 ## Preparing for production
-import PreparingForProduction from '../../shared/PreparingForProduction.mdx'
+
+import PreparingForProduction from '../../shared/PreparingForProduction.mdx';
 
 <PreparingForProduction />

--- a/js-sdk/shared/PreparingForProduction.mdx
+++ b/js-sdk/shared/PreparingForProduction.mdx
@@ -1,5 +1,5 @@
 In production mode, you should never use localization data from Tolgee REST API and never leak your API key.
 You should use data exported from the Tolgee platform.
-To get exported localization files, see [exporting translations](/platform/exporting_translations).
+To get exported localization files, see [exporting translations](/platform/projects_and_organizations/export).
 
 Then provide the data via Tolgee configuration options described in [Providing static data](/providing_static_data.mdx).

--- a/js-sdk_versioned_docs/version-4.x.x/configuration.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/configuration.mdx
@@ -10,14 +10,17 @@ All Tolgee JS integrations such as integration library for Angular or React shar
 ## Configuration properties
 
 ### apiUrl
+
 Url of Tolgee server.
 
 ### apiKey
-Your api key, which can be [obtained using Tolgee web application.](/platform/api-keys-and-pat-tokens).
-When both `apiKey` and `apiUrl` properties are provided, Tolgee runs in `development` mode, 
+
+Your api key, which can be [obtained using Tolgee web application.](/platform/account_settings/api_keys_and_pat_tokens).
+When both `apiKey` and `apiUrl` properties are provided, Tolgee runs in `development` mode,
 otherwise it runs in `production` mode.
 
 ### inputPrefix and inputSuffix
+
 In development mode, strings to be translated are wrapped by `@tolgee/core` library at first and then parsed and replaced with
 translated value. This mechanism is called [wrapping](./wrapping).
 
@@ -26,6 +29,7 @@ Tolgee recognises strings, which are meant to be translated, so its good idea to
 with any other strings, which can appear in DOM.
 
 Example:
+
 ```typescript
 inputPrefix = '%-%tolgee:';
 inputSuffix = '%-%';
@@ -34,28 +38,34 @@ inputSuffix = '%-%';
 These strings are unique enough to not clash with any other strings in your DOM, so it will not break your document.
 
 ### defaultLanguage
+
 Default language to be set by as currentLanguage default. (default: `en`)
 
 ### fallbackLanguage
+
 When translation is not provided in current language, Tolgee tries to find it in fallbackLanguage.
 (default: value of `defaultLanguage` property)
 
 ### forceLanguage
+
 By default, Tolgee tries to set the language according to user's system language. Sometimes you need to force it to
 use specific language. For example when you are working with SSR or your language is determined by route.
 Providing value to forceLanguage will disable language switching and Tolgee will use just the forced language.
+
 ```js
 const config = {
-  forceLanguage: 'en'
-}
+  forceLanguage: 'en',
+};
 ```
 
 ### preloadFallback
+
 When `true` Tolgee loads both current language and fallback language before promise is resolved from `Tolgee.run()` method.
 Otherwise, Tolgee will try to load fallback language localization data just when it's needed (when some translation is missing in current language).
 That way some inappropriate value may be rendered when some text is missing in current language. (default `false`)
 
 ### availableLanguages
+
 Tolgee chooses language automatically by user's default language provided by
 [browser navigator object](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language). To do so, it
 needs to know which languages are available to determine whether user's preferred language is supported by your app.
@@ -65,22 +75,27 @@ If user's language is not available, `defaultLanguage` is used instead.
 Default: `['en']`
 
 ### enableLanguageStore
+
 Automatically store user language in localStorage. (default `true`)
 
 ### enableLanguageDetection
+
 Use auto language detection by browser locale. (default `true`)
 
 ### filesUrlPrefix
+
 In production mode, localization texts are loaded from json files, which are loaded from url prefixed with this property
 value.
 
 When your current language is "en" and your `filesUrlPrefix` is `https://example.com/loc/files/`,
 your localization data will be loaded from file loaded from url `https://example.com/loc/files/en.json`.
 
-You can obtain these files by [downloading them from Tolgee Web Application](/platform/exporting_translations)
+You can obtain these files by [downloading them from Tolgee Web Application](/platform/projects_and_organizations/export)
 
 ### staticData
+
 Using this property, you can provide localization data to Tolgee as an object. Tolgee will use this data in production mode.
+
 ```typescript
 import * as localeEn from 'i18n/en.json';
 import * as localeDe from 'i18n/de.json';
@@ -95,16 +110,18 @@ const config = {
 ```
 
 or you can provide the data using provider functions returning promises, so it works great with dynamic import feature:
+
 ```typescript
 const config = {
   staticData: {
-        en: () => import('./i18n/en.json'),
-        de: () => import('./i18n/de.json'),
-      }
-  };
+    en: () => import('./i18n/en.json'),
+    de: () => import('./i18n/de.json'),
+  },
+};
 ```
 
 ### watch
+
 In development mode, watch is always set to `true` because Tolgee needs to find strings to replace with translated values
 every time when DOM is changed. In production mode, watching is not always necessary because integration libraries for
 React and Angular return translated values directly without wrapping, so wrapped encoded strings are never inserted to DOM.
@@ -116,9 +133,11 @@ this to `true`.
 because this tutorial is framework independent and so no framework integration library is used.
 
 ### ui
+
 To use Tolgee in development with in-context localization, you need to provide a constructor for UI class.
 
 Example:
+
 ```
 ui: window["@tolgee/ui"].UI,
 ```
@@ -127,13 +146,16 @@ ui: window["@tolgee/ui"].UI,
 in development mode and may be omitted in production mode.
 
 ### targetElement
+
 Element where wrapped strings are expected in development mode. (default: `document.body`)
 
 ### tagAttributes
+
 Tolgee is able to watch also for wrapped localization strings in attributes of DOM elements. These attributes must be
 specified in these configuration properties.
 
 Default:
+
 ```javascript
 tagAttributes: {
     textarea: ['placeholder'],
@@ -144,6 +166,7 @@ tagAttributes: {
 ```
 
 ### highlightKeys
+
 By default, in development mode, when you move mouse over an element containing translated text and key `ALT` is down,
 this element is highlighted by changing its background color. To modify the key use `highlightKeys` property.
 
@@ -159,21 +182,22 @@ import {ModifierKey} from "../clients/js/packages/core/lib/index";
 
 Default: `[ModifierKey.Alt]`
 
-
 ### passToParent
+
 There are elements which can contain wrapped string to be translated, but user is not able to click on them. For example
 an option of `select` HTML element cannot be used for capturing click even with `ALT` down. For these reasons you can
 configure Tolgee to "pass" these strings to parent and listen for click events on the parent.
 
 Default: `["option", "optgroup"]`
 
-
 ### restrictedElement
+
 Array of elements in which you don't want Tolgee to replace wrapped strings.
 
 Default: `['script', 'style']`
 
 ### highlightColor
+
 Highlighter border color.
 
 Default: `rgb(255 0 0)`&nbsp;&nbsp;<div style={{
@@ -186,6 +210,7 @@ verticalAlign: "middle"
 }}></div>
 
 ### highlightWidth
+
 Border width of highlighter.
 
 Default: `5px`
@@ -194,5 +219,5 @@ Default: `5px`
 
 Will determine how are translations wrapped ([read more](./wrapping))
 
- - `text` (default) - uses standard wrapping
- - `invisible` (experimental) - uses zero width invisible characters to encode key info directly into translation
+- `text` (default) - uses standard wrapping
+- `invisible` (experimental) - uses zero width invisible characters to encode key info directly into translation

--- a/js-sdk_versioned_docs/version-4.x.x/get_started/hello_world.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/get_started/hello_world.mdx
@@ -16,53 +16,61 @@ Tolgee doesn't work properly when the app is opened as `.html` file from filesys
 :::
 
 Let's start with simple html code:
+
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Hello world</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Hello world!</h1>
-</body>
+  </body>
 </html>
 ```
+
 There is text `Hello world!` in the body, which we would like to translate.
 
 Loading Tolgee in your web application is as simple as including one dependency. To do so, we can simply use unpkg
 cdn:
+
 ```html
 <script src="https://unpkg.com/@tolgee/core/dist/tolgee.umd.min.js"></script>
 ```
 
 To translate your content interactively, you will need one more dependency.
+
 ```html
 <script src="https://unpkg.com/@tolgee/ui/dist/tolgee-ui.umd.min.js"></script>
 ```
+
 This dependency is Tolgee's UI, so dialog can appear when you **ALT + click** your translation.
 
 Now it's time to configure the library. To do so, just pass configuration object as first parameter of Tolgee constructor.
 :::info
 Initialization has changed in [version 3](../changelog/tolgee_js_version_3)
 :::
+
 ```html
 <script>
-const { Tolgee, IcuFormatter } = window["@tolgee/core"]
-const tg = Tolgee.use(IcuFormatter).init({
-    apiUrl: "https://app.tolgee.io",
-    apiKey: "you_secret_api_key",
-    inputPrefix: "{{",
-    inputSuffix: "}}",
+  const { Tolgee, IcuFormatter } = window['@tolgee/core'];
+  const tg = Tolgee.use(IcuFormatter).init({
+    apiUrl: 'https://app.tolgee.io',
+    apiKey: 'you_secret_api_key',
+    inputPrefix: '{{',
+    inputSuffix: '}}',
     watch: true,
-    ui: window["@tolgee/ui"].UI,
-});
+    ui: window['@tolgee/ui'].UI,
+  });
 </script>
 ```
+
 You can specify many other parameters in the configuration object, but in this example we stick with:
+
 - **apiUrl** - url of the api, where we are saving the data
 - **apiKey** - which you can obtain in the [app](https://app.tolgee.io) or in your self-hosted app by following
-[this documentation page](/platform/api-keys-and-pat-tokens)
+  [this documentation page](/platform/account_settings/api_keys_and_pat_tokens)
 - **inputPrefix** - character sequence which appears before the text you wish to translate
 - **inputSuffix** - character sequence which appears after the text you wish to translate
 - **watch** - parameter defining whether Tolgee should watch for changes in the DOM and update translations
@@ -72,45 +80,47 @@ Replace the text with the localization placeholder, wrapped with the `inputPrefi
 
 ```html
 <body>
-    <h1>{{hello_world}}</h1>
+  <h1>{{hello_world}}</h1>
 </body>
 ```
 
 Finally, lets run the beast!
 
 ```javascript
-tg.run().then(() => {})
+tg.run().then(() => {});
 ```
 
 You should end up with this HTML document:
+
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Hello world</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>{{hello_world}}</h1>
-</body>
-<script src="https://unpkg.com/@tolgee/core/dist/tolgee.umd.min.js"></script>
-<script src="https://unpkg.com/@tolgee/ui/dist/tolgee-ui.umd.min.js"></script>
-<script>
-const { Tolgee, IcuFormatter } = window["@tolgee/core"]
-const tg = Tolgee.use(IcuFormatter).init({
-    apiUrl: "https://app.tolgee.io",
-    apiKey: "you_secret_api_key",
-    inputPrefix: "{{",
-    inputSuffix: "}}",
-    watch: true,
-    ui: window["@tolgee/ui"].UI,
-});
-tg.run().then(() => {
-    // This block is executed after tolgee loads it's translation.
-    // So here you have nice possibility to remove your loading overlay
-})
-</script>
+  </body>
+  <script src="https://unpkg.com/@tolgee/core/dist/tolgee.umd.min.js"></script>
+  <script src="https://unpkg.com/@tolgee/ui/dist/tolgee-ui.umd.min.js"></script>
+  <script>
+    const { Tolgee, IcuFormatter } = window['@tolgee/core'];
+    const tg = Tolgee.use(IcuFormatter).init({
+      apiUrl: 'https://app.tolgee.io',
+      apiKey: 'you_secret_api_key',
+      inputPrefix: '{{',
+      inputSuffix: '}}',
+      watch: true,
+      ui: window['@tolgee/ui'].UI,
+    });
+    tg.run().then(() => {
+      // This block is executed after tolgee loads it's translation.
+      // So here you have nice possibility to remove your loading overlay
+    });
+  </script>
 </html>
 ```
+
 After opening this document in a browser you should be able to `ALT + click` your text and translate it directly.
 After that you should see your translated version right away!

--- a/js-sdk_versioned_docs/version-4.x.x/get_started/parameter_interpolation.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/get_started/parameter_interpolation.mdx
@@ -15,27 +15,38 @@ formatter that it should replace wrapped string with provided value.
 
 :::info
 Tolgee uses ICU message format in all its implementations. To learn more about ICU message format, visit this
-[ICU message format doc page](/platform/icu_message_format).
+[ICU message format doc page](/platform/translation_process/icu_message_format).
 :::
 
 To provide parameters and its values, append them after the key or default value delimited with ":" character.
 Multiple parameters are delimited with "," character.
 
 ```html
-<h1>{{hello,Hello {name} {surname}:name:John,surname:Doe}}<h1>
+<h1>
+  {{hello,Hello {name} {surname}:name:John,surname:Doe}}
+  <h1></h1>
+</h1>
 ```
 
 You can also omit the default value, ft you don't want to provide it in your code.
+
 ```html
-<h1>{{hello:name:John,surname:Doe}}<h1>
+<h1>
+  {{hello:name:John,surname:Doe}}
+  <h1></h1>
+</h1>
 ```
 
 ## Parameter interpolation when translating imperatively
+
 To provide parameters object to the `translate` function pass it as the 2nd argument.
+
 ```javascript
 tg.translate("hello", {name: "John", surname: "Doe"}).then((t) => ...);
 ```
+
 or use props object
+
 ```javascript
 tg.translate({
   key: "hello",
@@ -45,15 +56,17 @@ tg.translate({
 ```
 
 The same way you can pass the values to the `instant` method.
+
 ```javascript
-const value = tg.instant("hello", {name: "John", surname: "Doe"});
+const value = tg.instant('hello', { name: 'John', surname: 'Doe' });
 ```
 
 or use props object
+
 ```javascript
 const value = tg.instant({
-  key: "hello",
-  defaultValue: "Hello {name} {surname}.",
-  params: {name: "John", surname: "Doe"}
+  key: 'hello',
+  defaultValue: 'Hello {name} {surname}.',
+  params: { name: 'John', surname: 'Doe' },
 });
 ```

--- a/js-sdk_versioned_docs/version-4.x.x/get_started/parameter_interpolation.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/get_started/parameter_interpolation.mdx
@@ -22,19 +22,13 @@ To provide parameters and its values, append them after the key or default value
 Multiple parameters are delimited with "," character.
 
 ```html
-<h1>
-  {{hello,Hello {name} {surname}:name:John,surname:Doe}}
-  <h1></h1>
-</h1>
+<h1>{{hello,Hello {name} {surname}:name:John,surname:Doe}}</h1>
 ```
 
 You can also omit the default value, ft you don't want to provide it in your code.
 
 ```html
-<h1>
-  {{hello:name:John,surname:Doe}}
-  <h1></h1>
-</h1>
+<h1>{{hello:name:John,surname:Doe}}</h1>
 ```
 
 ## Parameter interpolation when translating imperatively

--- a/js-sdk_versioned_docs/version-4.x.x/get_started/preparing_for_production.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/get_started/preparing_for_production.mdx
@@ -6,7 +6,7 @@ slug: /get_started/preparing_for_production
 ---
 
 In production environment, you should never leak your API key. In-context localization must be available only for your translators,
- developers or other staff but not for the outside world.
+developers or other staff but not for the outside world.
 
 :::warning
 
@@ -16,10 +16,11 @@ Never leak your API key! We strongly recommend against adding API key into git r
 
 To prepare your application for production you will need to let Tolgee use exported .json files.
 You can get these files by exporting your translations from web application.
-See [exporting translations](/platform/exporting_translations).
+See [exporting translations](/platform/projects_and_organizations/export).
 
 To make Tolgee look for json files just remove **apiKey** property from configuration object. If we continue with
 our [hello world example](hello_world), production configuration object will look like this:
+
 ```javascript
 {
     inputPrefix: "{{",
@@ -37,6 +38,7 @@ To change this, you may provide `filesUrlPrefix` property to configuration objec
 default.
 
 Let's take the exported json files and put them into the i18n directory placed as a sibling of our html file:
+
 ```
 ├── i18n
 │   ├── cs.json
@@ -45,26 +47,28 @@ Let's take the exported json files and put them into the i18n directory placed a
 ```
 
 That's it! Our app is ready for production. Here is the final HTML page:
+
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>hello world</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>{{hello_world}}</h1>
-</body>
-<script src="https://unpkg.com/@tolgee/core/dist/tolgee.umd.min.js"></script>
-<script>
-const { Tolgee, IcuFormatter } = window["@tolgee/core"]
-const tg = Tolgee.use(IcuFormatter).init({
-    inputPrefix: "{{",
-    inputSuffix: "}}",
-    watch: true,
-});
-tg.run();
-</script>
+  </body>
+  <script src="https://unpkg.com/@tolgee/core/dist/tolgee.umd.min.js"></script>
+  <script>
+    const { Tolgee, IcuFormatter } = window['@tolgee/core'];
+    const tg = Tolgee.use(IcuFormatter).init({
+      inputPrefix: '{{',
+      inputSuffix: '}}',
+      watch: true,
+    });
+    tg.run();
+  </script>
 </html>
 ```
+
 Now you maybe wish to [add loading overlay](adding_loading_overlay.mdx) to make untranslated texts invisible.

--- a/js-sdk_versioned_docs/version-4.x.x/in_context.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/in_context.mdx
@@ -3,18 +3,18 @@ id: in_context
 title: In-context translating
 sidebar_label: In-context translating
 slug: /in_context
-description: "Learn how to use in-context translating feature in Tolgee tool and how to enable in-context translating on production."
+description: 'Learn how to use in-context translating feature in Tolgee tool and how to enable in-context translating on production.'
 ---
 
-For local development, supply `apiUrl`,`apiKey` and `ui` to Tolgee configuration (see [Integration](/platform/integration)). If you set everything properly, you can use in-context translating:
+For local development, supply `apiUrl`,`apiKey` and `ui` to Tolgee configuration (see [Integration](/platform/integrations/about_integrations)). If you set everything properly, you can use in-context translating:
 
- 1. Press and hold `Alt`/`Option` key
- 2. Navigate mouse over any translation on your website
- 3. It should get highlighted
- 4. Click on it to open "Quick translation" dialog
- 5. You can edit translations (changes will get stored to Tolgee platform)
+1.  Press and hold `Alt`/`Option` key
+2.  Navigate mouse over any translation on your website
+3.  It should get highlighted
+4.  Click on it to open "Quick translation" dialog
+5.  You can edit translations (changes will get stored to Tolgee platform)
 
-<video loop autoPlay muted style={{ maxWidth: "100%", margin: "0 auto" }}>
+<video loop autoPlay muted style={{ maxWidth: '100%', margin: '0 auto' }}>
   <source src="/in-context-development.mov"></source>
 </video>
 
@@ -27,20 +27,20 @@ Never include `apiKey` in Tolgee configuration on production.
 This property is intended only for local development, as it's not meant to be publicly visible.
 :::
 
- 1. Install [Tolgee Tools](https://chrome.google.com/webstore/detail/tolgee-tools/hacnbapajkkfohnonhbmegojnddagfnj) plugin
- 2. Go to the production version of your website
- 3. Click on Tolgee Tools extension and apply your API key (you might need to reload if you just installed the plugin)
- 4. In-context translating should work
+1.  Install [Tolgee Tools](https://chrome.google.com/webstore/detail/tolgee-tools/hacnbapajkkfohnonhbmegojnddagfnj) plugin
+2.  Go to the production version of your website
+3.  Click on Tolgee Tools extension and apply your API key (you might need to reload if you just installed the plugin)
+4.  In-context translating should work
 
 > You can also check [Step-by-step tutorial](/blog/in-context-production)
 
-<video loop autoPlay muted style={{ maxWidth: "100%", margin: "0 auto" }}>
+<video loop autoPlay muted style={{ maxWidth: '100%', margin: '0 auto' }}>
   <source src="/in-context-production.mov"></source>
 </video>
 
 #### A few notes about Tolgee Tools plugin
 
- - You can turn off development mode by switching "Applied" toggle, which will turn it off, but stores credentials locally so you don't have to fill it again next time
- - Plugin will supply `apiUrl` from Tolgee configuration if it's present (if not you can fill it manually)
- - Plugin will not allow you to modify credentials if you are in development mode already
- - Plugin changes its icon if Tolgee is present on the page or if credentials are set
+- You can turn off development mode by switching "Applied" toggle, which will turn it off, but stores credentials locally so you don't have to fill it again next time
+- Plugin will supply `apiUrl` from Tolgee configuration if it's present (if not you can fill it manually)
+- Plugin will not allow you to modify credentials if you are in development mode already
+- Plugin changes its icon if Tolgee is present on the page or if credentials are set

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_angular/preparing_for_production.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_angular/preparing_for_production.mdx
@@ -4,9 +4,10 @@ title: Preparing for production (Angular)
 sidebar_label: Preparing for production
 slug: /using_with_angular/angular_preparing_for_production
 ---
+
 In production mode you should never use localization data from Tolgee REST API and you should never leak your API key.
 You should use data exported from Tolgee platform.
-To get exported localization files, see [exporting translations](/platform/exporting_translations).
+To get exported localization files, see [exporting translations](/platform/projects_and_organizations/export).
 
 There are multiple options to provide static localization data for production builds. Providing a URL prefix where Tolgee can
 fetch the data from or providing imported data as reference or provider in `NgxTolgeeModule.forRoot(...)` config property.
@@ -17,13 +18,13 @@ To provide your localization data using dynamic import you will need to add prov
 to staticData configuration property.
 
 ```typescript jsx title="src/app/app.module.ts"
-import { BrowserModule } from "@angular/platform-browser";
-import { NgModule } from "@angular/core";
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
 
-import { AppComponent } from "./app.component";
-import { NgxTolgeeModule } from "@tolgee/ngx";
-import { environment } from "../environments/environment";
-import { FormsModule } from "@angular/forms";
+import { AppComponent } from './app.component';
+import { NgxTolgeeModule } from '@tolgee/ngx';
+import { environment } from '../environments/environment';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent],
@@ -31,8 +32,8 @@ import { FormsModule } from "@angular/forms";
     BrowserModule,
     NgxTolgeeModule.forRoot({
       staticData: {
-        en: () => import("../assets/i18n/en.json"),
-        cs: () => import("../assets/i18n/cs.json"),
+        en: () => import('../assets/i18n/en.json'),
+        cs: () => import('../assets/i18n/cs.json'),
       },
     }),
     FormsModule,
@@ -41,24 +42,24 @@ import { FormsModule } from "@angular/forms";
   bootstrap: [AppComponent],
 })
 export class AppModule {}
-
 ```
 
 Using this approach data will be fetched just when it's needed, so you will save some network traffic.
 
 ## Using imported object
+
 This approach just provides localization data as imported object.
 
 ```typescript jsx title="src/app/app.module.ts"
-import { BrowserModule } from "@angular/platform-browser";
-import { NgModule } from "@angular/core";
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
 
-import { AppComponent } from "./app.component";
-import { NgxTolgeeModule } from "@tolgee/ngx";
-import { environment } from "../environments/environment";
-import { FormsModule } from "@angular/forms";
-import * as localeCs from "../assets/i18n/cs.json";
-import * as localeEn from "../assets/i18n/en.json";
+import { AppComponent } from './app.component';
+import { NgxTolgeeModule } from '@tolgee/ngx';
+import { environment } from '../environments/environment';
+import { FormsModule } from '@angular/forms';
+import * as localeCs from '../assets/i18n/cs.json';
+import * as localeEn from '../assets/i18n/en.json';
 
 @NgModule({
   declarations: [AppComponent],
@@ -77,17 +78,19 @@ import * as localeEn from "../assets/i18n/en.json";
 })
 export class AppModule {}
 ```
+
 This way, all localization data are bundled with your application, so it will be downloaded with your application code.
 
 ## Providing data using filesUrlPrefix option (default)
-```typescript jsx title="src/app/app.module.ts"
-import { BrowserModule } from "@angular/platform-browser";
-import { NgModule } from "@angular/core";
 
-import { AppComponent } from "./app.component";
-import { NgxTolgeeModule } from "@tolgee/ngx";
-import { environment } from "../environments/environment";
-import { FormsModule } from "@angular/forms";
+```typescript jsx title="src/app/app.module.ts"
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+
+import { AppComponent } from './app.component';
+import { NgxTolgeeModule } from '@tolgee/ngx';
+import { environment } from '../environments/environment';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent],
@@ -95,7 +98,7 @@ import { FormsModule } from "@angular/forms";
     BrowserModule,
     NgxTolgeeModule.forRoot({
       // this value is default, so we could have omitted this property
-      filesUrlPrefix: "assets/i18n/",
+      filesUrlPrefix: 'assets/i18n/',
     }),
     FormsModule,
   ],
@@ -103,7 +106,7 @@ import { FormsModule } from "@angular/forms";
   bootstrap: [AppComponent],
 })
 export class AppModule {}
-
 ```
+
 This option tells Tolgee, that localization data (en.json, cs.json) can be found on `https://yoururl.com/assets/i18n/`,
 so it will be fetched with every page load.

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_angular/translating.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_angular/translating.mdx
@@ -3,7 +3,7 @@ id: translating
 title: Translating with Angular
 sidebar_label: Translating
 slug: /using_with_angular/translating
-description: "Learn how to translate with Angular, and how to safely translating without wrapping. To translate strings in Angular you can use pipe or translation methods."
+description: 'Learn how to translate with Angular, and how to safely translating without wrapping. To translate strings in Angular you can use pipe or translation methods.'
 ---
 
 To get full image of working Angular integration check our [Angular example application](https://github.com/tolgee/ngx-example).
@@ -11,6 +11,7 @@ To get full image of working Angular integration check our [Angular example appl
 To translate strings in Angular you can use pipe or translation methods.
 
 ## Using pipe
+
 To translate a string use [`translate`](api#translate-pipe) pipe.
 
 ```html
@@ -20,7 +21,7 @@ To translate a string use [`translate`](api#translate-pipe) pipe.
 To provide parameters for translation pass them as first parameter of `translate` pipe.
 
 ```typescript
-params = {name: "John Doe"};
+params = { name: 'John Doe' };
 ```
 
 ```html
@@ -28,46 +29,55 @@ params = {name: "John Doe"};
 ```
 
 You can also provide default value.
+
 ```html
-<h1>{{'hello' | translate:params:'Default!'}}</h1> // with params
-<h1>{{'hello' | translate:'Default!'}}</h1> // or without params
+<h1>{{'hello' | translate:params:'Default!'}}</h1>
+// with params
+<h1>{{'hello' | translate:'Default!'}}</h1>
+// or without params
 ```
 
 ## [Element with `t` attribute](api#tcomponent)
+
 You can also use [element with `t`](api#tcomponent) attribute. Angular will render Tolgee component with `t` attribute selector.
+
 ```html
 <h1 t key="providing_default_values"></h1>
-<p t key="Peter has n dogs" [params]="params"></p> // with params
+<p t key="Peter has n dogs" [params]="params"></p>
+// with params
 ```
 
 Default value can be provided as well
+
 ```html
 <p t key="using_t_with_default" default="This is default"></p>
 ```
 
 ## Using translate methods
+
 To translate texts in your component code use [`get`](api#method-get)
-or [`instant`](api#method-instant)  method.
+or [`instant`](api#method-instant) method.
 
 These methods are part of translateService, which can be injected by dependency injection:
 
 ```typescript
-import {Component, OnInit} from '@angular/core';
-import {TranslateService} from "@tolgee/ngx";
+import { Component, OnInit } from '@angular/core';
+import { TranslateService } from '@tolgee/ngx';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: ['./app.component.css'],
 })
 export class AppComponent implements OnInit {
-
   constructor(private translateService: TranslateService) {}
 
   helloWorld: string;
 
   async ngOnInit(): Promise<void> {
-    this.translateService.get('hello_world').subscribe(r => this.helloWorld = r);
+    this.translateService
+      .get('hello_world')
+      .subscribe((r) => (this.helloWorld = r));
   }
 }
 ```
@@ -75,9 +85,10 @@ export class AppComponent implements OnInit {
 `get` method returns [**Observable**](https://rxjs-dev.firebaseapp.com/guide/observable) as the result. That means, the
 result is provided asynchronously, when the localization strings are loaded.
 
-
 ```typescript
-this.translateService.get('hello_world').subscribe(r => this.helloWorld = r);
+this.translateService
+  .get('hello_world')
+  .subscribe((r) => (this.helloWorld = r));
 ```
 
 If you are unable to use this asynchronous approach for some reason, you can use
@@ -102,10 +113,13 @@ to [`get`](api#method-get) or
 [`instant`](api#method-instant) functions.
 
 ```typescript
-this.translateService.get('hello', {name: "John Doe"}).subscribe(r => this.hello = r);
+this.translateService
+  .get('hello', { name: 'John Doe' })
+  .subscribe((r) => (this.hello = r));
 ```
 
 ## Safe translating (without wrapping)
+
 When translating with Tolgee, there could be situations, when your texts are rendered incorrectly because of
 [wrapping](/wrapping.mdx).
 For example encoded strings like `%-%tolgee:something%-%` will be rendered in your document or tooltips will be rendered
@@ -124,10 +138,11 @@ To change language, use [`setLang`](api#method-setlang) method of
 [`translateService`](api#translateservice).
 
 ```typescript
-this.translateService.setLang("en");
+this.translateService.setLang('en');
 ```
 
 ## Obtaining current language
+
 To obtain current language, use [`getCurrentLang`](api#method-getcurrentlang)
 method of [`translateService`](api#translateservice).
 
@@ -136,6 +151,7 @@ this.translateService.getCurrentLang();
 ```
 
 ## Subscribing to language change event
+
 Your imperatively translated texts will be not automatically updated in production mode. To do so, you will need to
 listen to onLanguageChange EventEmitter and refresh your values manually.
 
@@ -150,7 +166,6 @@ listen to onLanguageChange EventEmitter and refresh your values manually.
   }
 ```
 
-
 ## Translations with HTML tags
 
 Our JS SDKs currently don't support rendering of HTML tags natively. However, if you really really need to render HTML tags there is a way.
@@ -160,6 +175,7 @@ This is dangerous, and you should know what you are doing.
 :::
 
 Consider a translation value:
+
 ```
 '<h1>'Hello'</h1>'
 ```
@@ -168,15 +184,14 @@ Notice that `h1` tags are wrapped with `'` characters. This tells ICU message fo
 To get HTML you can use [`TranslateService.getSafe`](api#method-getsafe) method.
 
 ```ts
-this.translateService
-  .getSafe('key_with_html_translation', undefined)
-  .subscribe(
-    (r) => (this.translated = r) // r is <h1>Hello</h1>
-  );
+this.translateService.getSafe('key_with_html_translation', undefined).subscribe(
+  (r) => (this.translated = r) // r is <h1>Hello</h1>
+);
 ```
 
 Nice, but Angular doesn't allow us to set HTML into element so easily, so we have to set it using `[innerHtml]` attribute,
 which enables us to set inner HTML of the element.
+
 ```html
 <div
   data-tolgee-key-only="key_with_html_translation"
@@ -194,11 +209,12 @@ TIP: Maybe you can remove tags from your translated value or parameters using [s
 :::
 
 ## Message format
+
 All Tolgee integrations follow ICU message format standard.
 
-```{dogsCount, plural, one {One dog is} other {# dogs are}} here.```
+`{dogsCount, plural, one {One dog is} other {# dogs are}} here.`
 
 To read more about it, check
-[ICU Message Format](/platform/icu_message_format) documentation page.
+[ICU Message Format](/platform/translation_process/icu_message_format) documentation page.
 
 All Tolgee JS integrations are using [MessageFormat class of formatJs library](https://formatjs.io/docs/intl-messageformat/).

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_i18next/preparing_for_production.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_i18next/preparing_for_production.mdx
@@ -4,9 +4,10 @@ title: Preparing for production (i18next)
 sidebar_label: Preparing for production
 slug: /using_with_i18next/preparing_for_production
 ---
+
 In production mode you should never use localization data from Tolgee REST API and you should never leak your API key.
 You should use data exported from Tolgee platform.
-To get exported localization files, see [exporting translations](/platform/exporting_translations).
+To get exported localization files, see [exporting translations](/platform/projects_and_organizations/export).
 
 There are multiple options to provide static localization data for production builds. Providing a URL prefix where Tolgee can
 fetch the data from or providing imported data as reference or provider in TolgeeProvider config prop.
@@ -29,6 +30,7 @@ withTolgee(i18n, {
 Using this approach data will be fetched just when it's needed, so you will save some network traffic.
 
 ## Using imported object
+
 ```ts
 import * as localeEn from 'i18n/en.json';
 import * as localeDe from 'i18n/de.json';
@@ -46,6 +48,7 @@ Using this approach, all localization data are bundled with your application, so
 This approach could be very useful for SSR, when you need your localization data imported to be rendered by your SSR engine.
 
 ## Providing data using filesUrlPrefix option
+
 ```ts
 withTolgee(i18n, {
   filesUrlPrefix: 'i18n/'

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_react/api.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_react/api.mdx
@@ -131,7 +131,10 @@ const Component = () => {
   const getLanguage = useCurrentLanguage();
 
   return (
-    <select onChange={(e) => setLanguage(e.target.value)} value={getLanguage()}>
+    <select
+      onChange={(e) => setLanguage(e.target.value)}
+      value={getLanguage()}
+    >
       ...
     </select>
   );

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_react/api.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_react/api.mdx
@@ -3,7 +3,7 @@ id: api
 title: API of Tolgee for React
 sidebar_label: API
 slug: /using_with_react/api
-description: "API documentation for React integration: TolgeeProvider​, T-component and different hooks ( useCurrentLanguage, useSetLanguage, useTranslate)."
+description: 'API documentation for React integration: TolgeeProvider​, T-component and different hooks ( useCurrentLanguage, useSetLanguage, useTranslate).'
 ---
 
 ## TolgeeProvider
@@ -18,35 +18,43 @@ import { TolgeeProvider } from '@tolgee/react';
 </TolgeeProvider>
 ```
 
-#### Prop `loadingFallback?` 
+#### Prop `loadingFallback?`
+
 `React.Node` - it is rendered when Tolgee is loading translations instead of provided content.
 You can pass custom loading element when using Vue with JSX.
 
 #### Config as props
+
 All keys from [`TolgeeConfiguration`](../configuration) object can be used as props.
 
-
-
 ## T component
+
 ```jsx
 import { T } from '@tolgee/react';
 
-<T keyName="..." parameters={{ param: '...' }}>default value ...</T>
+<T keyName="..." parameters={{ param: '...' }}>
+  default value ...
+</T>;
 ```
 
 #### Prop `keyName?`
+
 `String` - translation key.
 
 #### Prop `parameters?`
-`Record<string, string | number | ReactElement | (val) => ReactNode>` - variable parameters, which can be used in translation value 
-(read more about [ICU message format](/platform/icu_message_format)).
+
+`Record<string, string | number | ReactElement | (val) => ReactNode>` - variable parameters, which can be used in translation value
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 #### Prop `noWrap?`
+
 `Boolean` (default: `false`)
- - `false` - in development mode translation will be [wrapped](../wrapping)
- - `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
+
+- `false` - in development mode translation will be [wrapped](../wrapping)
+- `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
 
 #### Children `defaultValue?` | `keyName?`
+
 `String` - If `keyName` property is not defined, child is taken as `keyName`. If it is present child can be used as `defaultValue`.
 
 ## Hook `useTranslate`
@@ -54,23 +62,23 @@ import { T } from '@tolgee/react';
 Use this hook to get `t` function, which can be used for imperative translating.
 
 ```js
-import { useTranslate } from '@tolgee/react'
+import { useTranslate } from '@tolgee/react';
 
 const Component = () => {
-  const t = useTranslate()
+  const t = useTranslate();
 
-  return <div title={t('title_key')} />
-}
+  return <div title={t('title_key')} />;
+};
 ```
 
 ### Function `t`
 
-Returns requested translation and also subscribes component to translation/language changes, 
+Returns requested translation and also subscribes component to translation/language changes,
 so component will be re-rendered every time translation changes.
 
 ```ts
 function t(
-  key: string, 
+  key: string,
   parameters?: Record<string, string | number | ReactElement | (val) => ReactNode>,
   noWrap?: boolean,
   defaultValue?: string
@@ -86,19 +94,24 @@ function t(options: {
 ```
 
 #### Parameter `key`
+
 `String` - translation key.
 
 #### Parameter `parameters?`
-`Record<string, string | number | ReactElement | (val) => ReactNode>` - variable parameters, which can be used in translation value 
-(read more about [ICU message format](/platform/icu_message_format)).
+
+`Record<string, string | number | ReactElement | (val) => ReactNode>` - variable parameters, which can be used in translation value
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 #### Parameter `noWrap?`
+
 `Boolean` (default: `false`)
- - `false` - in development mode translation will be [wrapped](../wrapping)
- - `true` - use when wrapping in dev mode causes problems, or you pass write it outside the DOM 
-    (for example `document.title`), in this case in-context translation won't work
+
+- `false` - in development mode translation will be [wrapped](../wrapping)
+- `true` - use when wrapping in dev mode causes problems, or you pass write it outside the DOM
+  (for example `document.title`), in this case in-context translation won't work
 
 #### Parameter `defaultValue?`
+
 `String` - It will be rendered if there is no translation for this key (in selected language nor base language).
 If you won't provide this value, `key` will be rendered instead.
 
@@ -106,11 +119,9 @@ If you won't provide this value, `key` will be rendered instead.
 
 Returns function `getLanguage(): string`, which returns current language key.
 
-
 ## Hook `useSetLanguage`
 
 Returns function `setLanguage(lang: string)`, which changes language in Tolgee context.
-
 
 ```jsx title="useCurrentLanguage & useSetLanguage"
 import { useSetLanguage, useCurrentLanguage } from '@tolgee/react';
@@ -120,14 +131,9 @@ const Component = () => {
   const getLanguage = useCurrentLanguage();
 
   return (
-    <select
-      onChange={(e) => setLanguage(e.target.value)}
-      value={getLanguage()}
-    >
-      ...      
+    <select onChange={(e) => setLanguage(e.target.value)} value={getLanguage()}>
+      ...
     </select>
   );
-}
+};
 ```
-
-

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_react/preparing_for_production.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_react/preparing_for_production.mdx
@@ -4,9 +4,10 @@ title: Preparing for production (React)
 sidebar_label: Preparing for production
 slug: /using_with_react/preparing_for_production
 ---
+
 In production mode you should never use localization data from Tolgee REST API and you should never leak your API key.
 You should use data exported from Tolgee platform.
-To get exported localization files, see [exporting translations](/platform/exporting_translations).
+To get exported localization files, see [exporting translations](/platform/projects_and_organizations/export).
 
 There are multiple options to provide static localization data for production builds. Providing a URL prefix where Tolgee can
 fetch the data from or providing imported data as reference or provider in TolgeeProvider config prop.
@@ -31,6 +32,7 @@ TolgeeProvider's configuration property.
 Using this approach data will be fetched just when it's needed, so you will save some network traffic.
 
 ## Using imported object
+
 ```jsx
 import * as localeEn from 'i18n/en.json';
 import * as localeDe from 'i18n/de.json';
@@ -52,6 +54,7 @@ Using this approach, all localization data are bundled with your application, so
 This approach could be very useful for SSR, when you need your localization data imported to be rendered by your SSR engine.
 
 ## Providing data using filesUrlPrefix option
+
 ```jsx
 <TolgeeProvider
   filesUrlPrefix="i18n/"
@@ -60,5 +63,6 @@ This approach could be very useful for SSR, when you need your localization data
   ...
 </TolgeePrivider>
 ```
+
 This option tells Tolgee, that localization data (en.json, de.json) can be found on `https://<your url>/i18n`,
 so it will be fetched with every page load.

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_react/translating.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_react/translating.mdx
@@ -3,7 +3,7 @@ id: translating
 title: Translating with React
 sidebar_label: Translating
 slug: /using_with_react/translating
-description: "Learn about several ways how to translate a text using Tolgee React integration: T-component or useTranslate hook."
+description: 'Learn about several ways how to translate a text using Tolgee React integration: T-component or useTranslate hook.'
 ---
 
 There are several ways how to translate a text using our React integration.
@@ -21,7 +21,7 @@ import {T} from "@tolgee/react";
 To pass values just assign parameters property.
 
 ```jsx
-<T keyName="text_with_params" parameters={{ param: "value" }} />
+<T keyName="text_with_params" parameters={{ param: 'value' }} />
 ```
 
 For translated text `This is {param} of the text` it will result in `This is value of the text`.
@@ -32,9 +32,11 @@ translation feature for this particular occurrence.
 ### Providing default value
 
 When `keyName` property is provided, then children prop of [`T`](./api#t-component) component is considered as default value.
+
 ```jsx
 <T keyName="translation_key">This is default value.</T>
 ```
+
 The default value will be rendered when no translation is provided in current nor fallback language.
 
 ## `useTranslate` hook
@@ -52,20 +54,19 @@ t("key_to_translate")
 Function [`t`](./api#function-t) also accepts parameters object as second parameter:
 
 ```javascript
-t("key_to_translate", { param: "value" });
+t('key_to_translate', { param: 'value' });
 ```
 
 For more complex codebase showing usage of Tolgee React integration check
 [React example application](https://github.com/tolgee/react-sampleapp).
 
-
-
 ## Message format
+
 All Tolgee integrations follow ICU message format standard.
 
-```{dogsCount, plural, one {One dog is} other {# dogs are}} here.```
+`{dogsCount, plural, one {One dog is} other {# dogs are}} here.`
 
 To read more about it, check
-[ICU Message Format](/platform/icu_message_format) documentation page.
+[ICU Message Format](/platform/translation_process/icu_message_format) documentation page.
 
 All Tolgee JS integrations are using [MessageFormat class of formatJs library](https://formatjs.io/docs/intl-messageformat/).

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_svelte/api.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_svelte/api.mdx
@@ -3,10 +3,11 @@ id: api
 title: Tolgee for Svelte API
 sidebar_label: API
 slug: /using_with_svelte/api
-description: "Tolgee for svelte API documentation. Tolgee Provider provides Tolgee instance. Use in root of your application."
+description: 'Tolgee for svelte API documentation. Tolgee Provider provides Tolgee instance. Use in root of your application.'
 ---
 
 ## [`TolgeeProvider`](api#tolgeeprovider)
+
 Provides Tolgee instance. Use in root of your application.
 
 ```svelte
@@ -25,24 +26,28 @@ Provides Tolgee instance. Use in root of your application.
 ```
 
 #### Prop `config`
+
 [`TolgeeConfig`](../configuration) object, which is passed to Tolgee instance.
 
 #### Slot `loading-fallback`
+
 Slot which is rendered, when translations are loading. It's not rendered, when translations are provided through
 staticData config property as object in production mode.
 
-Example when `loading-fallback` is  **not** rendered:
+Example when `loading-fallback` is **not** rendered:
+
 ```javascript
-import enLang from "../i18n/en.json" // data is static
+import enLang from '../i18n/en.json'; // data is static
 const tolgeeConfig = {
   // ...
   staticData: {
-    en: enLang
-  }
+    en: enLang,
+  },
 };
 ```
 
 Example when `loading-fallback` is rendered:
+
 ```javascript
 const tolgeeConfig = {
   ...
@@ -53,6 +58,7 @@ const tolgeeConfig = {
 ```
 
 ## T component
+
 ```svelte
 <script>
   import { T } from "@tolgee/svelte";
@@ -62,30 +68,37 @@ const tolgeeConfig = {
 ```
 
 #### Prop `keyName`
+
 `String` - translation key.
 
 #### Prop `parameters?`
+
 `Record<string, string>` - variable parameters, which can be used in translation value
-(read more about [ICU message format](/platform/icu_message_format)).
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 #### Prop `noWrap?`
+
 `Boolean` (default: `false`)
- - `false` - in development mode translation will be [wrapped](../wrapping)
- - `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
+
+- `false` - in development mode translation will be [wrapped](../wrapping)
+- `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
 
 #### Prop `defaultValue?`
+
 `String` - You can pass default value, which will be rendered if there is no translation
 for this key (in selected language nor base language). If you won't provide this value, `keyName` will be rendered instead.
 
 ## `getTranslate` function
+
 Returns store containing translating function
+
 ```typescript
 function t(
   key: string,
   parameters: Record<string, string>,
   noWrap?: boolean,
   defaultValue?: string
-): string
+): string;
 
 // or with options object
 function t(options: {
@@ -93,10 +106,11 @@ function t(options: {
   parameters?: Record<string, string>;
   noWrap?: boolean;
   defaultValue?: string;
-}): string
+}): string;
 ```
 
 Example:
+
 ```svelte
 <script>
   import { getTranslate } from "@tolgee/svelte";
@@ -119,33 +133,34 @@ Example:
 ```
 
 #### Parameter `key`
+
 `String` - translation key
 
 #### Parameter `parameters?`
+
 `Record<string, string>` - variable parameters, which can be used in translation value
-(read more about [ICU message format](/platform/icu_message_format))
+(read more about [ICU message format](/platform/translation_process/icu_message_format))
 
 #### Parameter `noWrap?`
+
 `Boolean` (default: `false`)
+
 - `false` - in development mode translation will be [wrapped](../wrapping)
 - `true` - use when wrapping in dev mode causes problems, or you pass write it outside the DOM
-(for example `document.title`), in this case in-context translation won't work
+  (for example `document.title`), in this case in-context translation won't work
 
 #### Parameter `defaultValue?`
+
 `String` - It will be rendered if there is no translation for this key (in selected language nor base language).
 If you don't provide this value, `key` will be rendered instead.
 
 ## Function `getLanguageStore`
+
 `Writable<string>` - Writeable store containing the current language. (see [Switching language](switching_language))
 
 ```javascript
 <script>
-  import {getLanguageStore} from "@tolgee/svelte";
-
-  const languageStore = getLanguageStore();
-
-  languageStore.subscribe((lang) => console.log(lang));
+  import {getLanguageStore} from "@tolgee/svelte"; const languageStore =
+  getLanguageStore(); languageStore.subscribe((lang) => console.log(lang));
 </script>
 ```
-
-

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_svelte/preparing_for_production.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_svelte/preparing_for_production.mdx
@@ -4,13 +4,14 @@ title: Preparing for production
 sidebar_label: Preparing for production
 slug: /using_with_svelte/preparing_for_production
 ---
+
 :::danger
 In production mode you should never use localization data from Tolgee REST API and you should never leak your API key.
 :::
 
 :::info
 You should use data exported from Tolgee platform.
-To get exported localization files, see [Exporting translations doc page](/platform/exporting_translations).
+To get exported localization files, see [Exporting translations doc page](/platform/projects_and_organizations/export).
 :::
 
 In production, you should set the API key to `undefined` and provide exported translations.

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_svelte/translating.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_svelte/translating.mdx
@@ -3,8 +3,9 @@ id: translating
 title: Translating with Tolgee for Svelte
 sidebar_label: Translating
 slug: /using_with_svelte/translating
-description: "Learn about several ways how to translate a text using Tolgee Svelte integration: T-component and getTranslate method."
+description: 'Learn about several ways how to translate a text using Tolgee Svelte integration: T-component and getTranslate method.'
 ---
+
 When you have Tolgee libraries installed and [`TolgeeProvider`](api#tolgeeprovider) is set
 up, you can start to translate your strings.
 There are several ways how to translate a text using Tolgee Svelte integration.
@@ -22,26 +23,30 @@ First and the recommended way is the `<T>` component. You can use it like this:
 ```
 
 To provide parameters to you translation, use parameters prop.
+
 ```svelte
 <T keyName="greeting" parameters={{name: "Josh"}} />
 ```
+
 For translation `Hello {name}!` the rendered string will be `Hello Josh!`.
 
 Also, when you hold `Alt` key and move you mouse over the string, you should be able to click & translate the text
 in-context.
 
 We are using ICU message format. To read more about it, check
-[ICU Message Format](/platform/icu_message_format) documentation page.
+[ICU Message Format](/platform/translation_process/icu_message_format) documentation page.
 
 ### Providing default value
 
 You can also provide `defaultValue` prop to the [`T`](api#t-component) component. This value will be used when no translation
 has been found in localization data.
+
 ```svelte
 <T keyName="this_is_a_key" defaultValue="This is default." />
 ```
 
 ## `getTranslate` method
+
 If you cannot use `T` component for some reason, then you can also use
 [`getTranslate`](api#gettranslate-function) method returning store containing
 a translation function. The usage is very simple, look:
@@ -56,8 +61,10 @@ a translation function. The usage is very simple, look:
 <!-- use the translation function -->
 {$t({key: 'greeting', parameters: {name: "Josh"}, defaultValue: 'Hello {name}!'})}
 ```
+
 :::caution
 Don't use it with `context="module"`, it won't work, since the method is not called in component initialization.
+
 ```
 <script context="module"> // ❌
   import { getTranslate } from "@tolgee/svelte";
@@ -75,13 +82,15 @@ Don't use it with `context="module"`, it won't work, since the method is not cal
 ```
 
 :::
+
 ## Message format
+
 All Tolgee integrations follow ICU message format standard.
 
-```{dogsCount, plural, one {One dog is} other {# dogs are}} here.```
+`{dogsCount, plural, one {One dog is} other {# dogs are}} here.`
 
 To read more about it, check
-[ICU Message Format](/platform/icu_message_format) documentation page.
+[ICU Message Format](/platform/translation_process/icu_message_format) documentation page.
 
 All Tolgee JS integrations are using [MessageFormat class of formatJs library](https://formatjs.io/docs/intl-messageformat/).
 

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_vue/api.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_vue/api.mdx
@@ -3,10 +3,11 @@ id: api
 title: API
 sidebar_label: API
 slug: /using_with_vue/api
-description: "Detaile documentation to API in VueJS integration. TolgeeProvider​ Provides Tolgee context. Use in root of your application."
+description: 'Detaile documentation to API in VueJS integration. TolgeeProvider​ Provides Tolgee context. Use in root of your application.'
 ---
 
 ## TolgeeProvider
+
 Provides Tolgee context. Use in root of your application.
 
 ```js
@@ -14,19 +15,20 @@ import { TolgeeProvider } from '@tolgee/vue';
 ```
 
 ```html
-<TolgeeProvider config="...">
-  ... content ...
-</TolgeeProvider>
+<TolgeeProvider config="..."> ... content ... </TolgeeProvider>
 ```
 
 #### Prop `config`
+
 [`TolgeeConfiguration`](../configuration) object, which is passed to Tolgee instance.
 
-#### Prop `loadingFallback?` 
+#### Prop `loadingFallback?`
+
 `String | JSX.Element` - it is rendered when Tolgee is loading translations instead of provided content.
 You can pass custom loading element when using Vue with JSX.
 
 #### Slot `fallback`
+
 Alternative for `loadingFallback` use when you are using Vue with templates:
 
 ```html
@@ -39,6 +41,7 @@ Alternative for `loadingFallback` use when you are using Vue with templates:
 ```
 
 ## T component
+
 ```js
 import { T } from '@tolgee/vue';
 ```
@@ -48,18 +51,23 @@ import { T } from '@tolgee/vue';
 ```
 
 #### Prop `keyName`
+
 `String` - translation key.
 
 #### Prop `parameters?`
-`Record<string, string>` - variable parameters, which can be used in translation value 
-(read more about [ICU message format](/platform/icu_message_format)).
+
+`Record<string, string>` - variable parameters, which can be used in translation value
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 #### Prop `noWrap?`
+
 `Boolean` (default: `false`)
- - `false` - in development mode translation will be [wrapped](../wrapping)
- - `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
+
+- `false` - in development mode translation will be [wrapped](../wrapping)
+- `true` - use when wrapping in dev mode causes problems, in this case in-context translation won't work
 
 #### Prop `defaultValue?`
+
 `String` - You can pass default value, which will be rendered if there is no translation
 for this key (in selected language nor base language). If you won't provide this value, `keyName` will be rendered instead.
 
@@ -88,11 +96,11 @@ Function `t` has following interface:
 
 ```ts
 function t(
-  key: string, 
+  key: string,
   parameters: Record<string, string>,
   noWrap?: boolean,
   defaultValue?: string
-): string
+): string;
 
 // or with options object
 function t(options: {
@@ -100,7 +108,7 @@ function t(options: {
   parameters?: Record<string, string>;
   noWrap?: boolean;
   defaultValue?: string;
-}): string
+}): string;
 ```
 
 ### `useLanguage`
@@ -122,7 +130,6 @@ Returns reactive `language`, which you can use for language switching.
 </script>
 ```
 
-
 ## TolgeeMixin
 
 :::info
@@ -134,16 +141,17 @@ import { TolgeeMixin } from '@tolgee/vue';
 ```
 
 ### Function `$t`
-Returns requested translation and also subscribes component to translation/language changes, 
+
+Returns requested translation and also subscribes component to translation/language changes,
 so component will be re-rendered every time translation changes.
 
 ```ts
 function $t(
-  key: string, 
+  key: string,
   parameters: Record<string, string>,
   noWrap?: boolean,
   defaultValue?: string
-): string
+): string;
 
 // or with options object
 function $t(options: {
@@ -151,27 +159,33 @@ function $t(options: {
   parameters?: Record<string, string>;
   noWrap?: boolean;
   defaultValue?: string;
-}): string
+}): string;
 ```
 
 #### Parameter `key`
+
 `String` - translation key.
 
 #### Parameter `parameters?`
-`Record<string, string>` - variable parameters, which can be used in translation value 
-(read more about [ICU message format](/platform/icu_message_format)).
+
+`Record<string, string>` - variable parameters, which can be used in translation value
+(read more about [ICU message format](/platform/translation_process/icu_message_format)).
 
 #### Parameter `noWrap?`
+
 `Boolean` (default: `false`)
- - `false` - in development mode translation will be [wrapped](../wrapping)
- - `true` - use when wrapping in dev mode causes problems, or you pass write it outside the DOM 
-    (for example `document.title`), in this case in-context translation won't work
+
+- `false` - in development mode translation will be [wrapped](../wrapping)
+- `true` - use when wrapping in dev mode causes problems, or you pass write it outside the DOM
+  (for example `document.title`), in this case in-context translation won't work
 
 #### Parameter `defaultValue?`
+
 `String` - It will be rendered if there is no translation for this key (in selected language nor base language).
 If you won't provide this value, `key` will be rendered instead.
 
 ### Property `tolgeeLanguage`
+
 `String` - Reactive property, which contains current Tolgee language. Use it for reading or setting current language.
 
 ```html
@@ -179,4 +193,3 @@ If you won't provide this value, `key` will be rendered instead.
   ... languages ...
 </select>
 ```
-

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_vue/installation.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_vue/installation.mdx
@@ -3,7 +3,7 @@ id: installation
 title: Installation
 sidebar_label: Installation
 slug: /using_with_vue/installation
-description: "Learn how to install Tolgee Vue integration library and how to wrap your application with TolgeeProvider component."
+description: 'Learn how to install Tolgee Vue integration library and how to wrap your application with TolgeeProvider component.'
 ---
 
 :::info
@@ -15,7 +15,6 @@ Tolgee for Vue currently supports only Vue v3.
 :::
 
 To install Tolgee Vue integration library run:
-
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -56,19 +55,19 @@ First, you will need to wrap your application with [`TolgeeProvider`](./api#tolg
 </template>
 
 <script>
-import { TolgeeProvider } from '@tolgee/vue';
+  import { TolgeeProvider } from '@tolgee/vue';
 
-export default {
-  components: { TolgeeProvider },
-  data() {
-    return {
-      config: {
-        apiUrl: process.env.VUE_APP_TOLGEE_API_URL,
-        apiKey: process.env.VUE_APP_TOLGEE_API_KEY,
-      },
-    };
-  },
-}
+  export default {
+    components: { TolgeeProvider },
+    data() {
+      return {
+        config: {
+          apiUrl: process.env.VUE_APP_TOLGEE_API_URL,
+          apiKey: process.env.VUE_APP_TOLGEE_API_KEY,
+        },
+      };
+    },
+  };
 </script>
 ```
 
@@ -81,9 +80,9 @@ VUE_APP_TOLGEE_API_KEY=<your_api_key>
 
 Otherwise, you can set the properties directly, or you can use plugins like [dotenv-webpack plugin](https://www.npmjs.com/package/dotenv-webpack).
 
-> *Obtaining Tolgee API key is described in [integration](/platform/integration) chapter.*
-
+> _Obtaining Tolgee API key is described in [integration](/platform/integrations/about_integrations) chapter._
 
 ## Other configuration properties
+
 Configuration properties for all web integrations are similar. They are described in [configuration](../configuration)
 section.

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_vue/preparing_for_production.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_vue/preparing_for_production.mdx
@@ -4,13 +4,14 @@ title: Preparing for production
 sidebar_label: Preparing for production
 slug: /using_with_vue/preparing_for_production
 ---
+
 :::danger
 In production mode you should never use localization data from Tolgee REST API and you should never leak your API key.
 :::
 
 :::info
 You should use data exported from Tolgee platform.
-To get exported localization files, see [Exporting translations doc page](/platform/exporting_translations).
+To get exported localization files, see [Exporting translations doc page](/platform/projects_and_organizations/export).
 :::
 
 In production, you should set the API key to `undefined` and provide exported translations.
@@ -58,10 +59,10 @@ To provide your localization data using dynamic import, you will need to provide
 supported language to [TolgeeProvider's](api#tolgeeprovider) config prop.
 
 ```js
-import enLang from "../i18n/en.json"
-import deLang from "../i18n/de.json"
-import csLang from "../i18n/cs.json"
-import frLang from "../i18n/fr.json"
+import enLang from '../i18n/en.json';
+import deLang from '../i18n/de.json';
+import csLang from '../i18n/cs.json';
+import frLang from '../i18n/fr.json';
 
 export default defineComponent({
   data() {
@@ -72,9 +73,9 @@ export default defineComponent({
           en: enLang,
           cs: csLang,
           de: deLang,
-          fr: frLang
+          fr: frLang,
         },
-        availableLanguages: ["en", "de", "cs", "fr"]
+        availableLanguages: ['en', 'de', 'cs', 'fr'],
       },
     };
   },

--- a/js-sdk_versioned_docs/version-4.x.x/using_with_vue/translating.mdx
+++ b/js-sdk_versioned_docs/version-4.x.x/using_with_vue/translating.mdx
@@ -3,7 +3,7 @@ id: translating
 title: Translating with Vue
 sidebar_label: Translating
 slug: /using_with_vue/translating
-description: "Learn how to translate your Vue application with Tolgee localization tool: with the T-component or by Imperative translation."
+description: 'Learn how to translate your Vue application with Tolgee localization tool: with the T-component or by Imperative translation.'
 ---
 
 There are two ways how to translate with Tolgee.
@@ -16,22 +16,23 @@ There are two ways how to translate with Tolgee.
 </template>
 
 <script>
-import { T } from '@tolgee/vue';
+  import { T } from '@tolgee/vue';
 
-export default {
-  components: { T }
-}
+  export default {
+    components: { T },
+  };
 </script>
 ```
 
 ### Parameter interpolation
+
 To pass parameters, just add parameters property:
 
 ```html
 <T keyName="translation_key" :parameters="{param: 'value'}" />
 ```
 
-For translated text `This is {param} of the text` it will result in `This is value of the text` (read [ICU Message Format](/platform/icu_message_format)).
+For translated text `This is {param} of the text` it will result in `This is value of the text` (read [ICU Message Format](/platform/translation_process/icu_message_format)).
 
 ### Providing default value
 
@@ -45,7 +46,7 @@ The default value will be rendered when no translation is provided in current no
 
 This solution is designed for cases where you can't use components (e.g. props).
 Use [useTranslate](./api#usetranslate-with-function-t), then you'll get access to the [`t`](./api#function-t) function,
-which has similar API as [`T`](./api#t-component) component, but you can use it anywhere. 
+which has similar API as [`T`](./api#t-component) component, but you can use it anywhere.
 You can check all [`t`](./api#usetranslate-with-function-t) parameters in [API section](./api#usetranslate-with-function-t)
 
 ```html
@@ -59,6 +60,6 @@ You can check all [`t`](./api#usetranslate-with-function-t) parameters in [API s
       const t = useTranslate();
       return { t };
     },
-  }
+  };
 </script>
 ```

--- a/platform/integrations/figma_plugin/setup.mdx
+++ b/platform/integrations/figma_plugin/setup.mdx
@@ -12,7 +12,7 @@ Alternatively, you can find the plugin in Figma by opening the Resources > Plugi
 
 ## Setup
 
-After installing and launching the plugin, you need to insert an **API key**. If you don't have one, you can check out our documentation on [how to generate an API key](/platform/api-keys-and-pat-tokens#generation).
+After installing and launching the plugin, you need to insert an **API key**. If you don't have one, you can check out our documentation on [how to generate an API key](/platform/account_settings/api_keys_and_pat_tokens#generation).
 
 If you are using the self-hosted version, you can update the "Tolgee URL" field to the URL of your instance.
 

--- a/platform/translation_keys/keys.mdx
+++ b/platform/translation_keys/keys.mdx
@@ -20,7 +20,7 @@ To add new translation keys to Tolgee, you have a few options:
 - [Import](/platform/projects_and_organizations/import) a new translation file.
 - Use the editor to [create a single translation key](#creating-translation-keys-manually) and adjust its options as needed.
 - Use the [Tolgee API](/api) to add one or more keys through the [`create` endpoint](/api#tag/Localization-keys/operation/create_2).
-- Use the [Tolgee CLI (experimental)](/tolgee-cli) to add one or more keys with the [`push` command](/tolgee-cli/push-pull-strings#pushing-strings).
+- Use the [Tolgee CLI](/tolgee-cli) to add one or more keys with the [`push` command](/tolgee-cli/push-pull-strings#pushing-strings).
 - Use the [Tolgee Figma plugin](/platform/integrations/figma_plugin/setup) to add one or more keys with the [`Push` action](/platform/integrations/figma_plugin/usage#pushing-texts-from-figma-into-tolgee).
 
 ## Creating translation keys manually

--- a/src/pages/integrations/figma.tsx
+++ b/src/pages/integrations/figma.tsx
@@ -11,7 +11,7 @@ import Head from '@docusaurus/Head';
 
 const DocsLinks = ({ primary }: { primary?: boolean }) => (
   <LandingPageActions
-    docs={{ link: '/platform/figma-plugin/usage' }}
+    docs={{ link: '/platform/integrations/figma_plugin/usage' }}
     githubRepo={{
       explicitLink: true,
       link: 'https://github.com/tolgee/figma-plugin',

--- a/tolgee-cli/components/experimental.mdx
+++ b/tolgee-cli/components/experimental.mdx
@@ -1,6 +1,0 @@
-:::caution
-The Tolgee CLI is currently experimental and subject to bugs. **Breaking changes may happen before stable release!**
-
-Help us reach stable version faster by reporting any bug you encounter on the [issue tracker](https://github.com/tolgee/tolgee-cli/issues/new?labels=bug).
-Feedback is also greatly appreciated!
-:::

--- a/tolgee-cli/extraction/custom-extractor.mdx
+++ b/tolgee-cli/extraction/custom-extractor.mdx
@@ -3,10 +3,6 @@ id: custom-extractor
 title: Custom extractor
 ---
 
-import Experimental from '../components/experimental.mdx'
-
-<Experimental/>
-
 You can customize the extraction procedure by using a custom extractor. When using this setup, instead of relying on
 its own internal extractor Tolgee will use your script (written in JavaScript or TypeScript) to find and extract
 strings.

--- a/tolgee-cli/extraction/custom-extractor.mdx
+++ b/tolgee-cli/extraction/custom-extractor.mdx
@@ -3,8 +3,8 @@ id: custom-extractor
 title: Custom extractor
 ---
 
-You can customize the extraction procedure by using a custom extractor. When using this setup, instead of relying on
-its own internal extractor Tolgee will use your script (written in JavaScript or TypeScript) to find and extract
+You can customize the extraction process by using a custom extractor. When using this setup, instead of relying on
+its own internal extractor, Tolgee will use your script (written in JavaScript or TypeScript) to find and extract
 strings.
 
 :::caution
@@ -13,6 +13,7 @@ part of the internal extractor logic.
 :::
 
 ## Extractor structure
+
 There is not much to know when writing a custom extractor. Here is the bare minimum file structure to follow:
 
 ```ts title=extractor.ts
@@ -28,8 +29,9 @@ export default function (code: string, fileName: string): ExtractionResult {
 ```
 
 ## Using your custom extractor
+
 All commands using code extraction allow you to specify a `--extractor` option which takes a path to the extraction
-script to use. You can also configure it for the project via [`.tolgeerc`](/tolgee-cli/project-configuration)
+script to use. You can also configure it for the project via [`.tolgeerc`](/tolgee-cli/project-configuration).
 
 :::caution
 When using TypeScript to write your extractor, you must also install `ts-node` as the CLI will use it to load the
@@ -38,34 +40,36 @@ file.
 
 :::tip
 [`tolgee extractor print`](/tolgee-cli/extraction/syncing-strings#dumping-all-strings) is a very helpful command to
-test and troubleshoot your extractor. I'll dump all the keys it found and the warnings emitted to the console.
+test and troubleshoot your extractor. It will dump all the keys it found and the warnings emitted to the console.
 :::
 
 ## Type definitions
+
 Here is the type definition of `ExtractionResult`:
+
 ```ts title=extractor.d.ts
 type Warning = {
   /** Warning message */
-  warning: string
+  warning: string;
   /** Line where the warning was emitted */
-  line: number
-}
+  line: number;
+};
 
 type Key = {
   /** Name of the key */
-  keyName: string
+  keyName: string;
   /** Default value used when creating the key */
-  defaultValue?: string
+  defaultValue?: string;
   /** Namespace of the key */
-  namespace?: string
+  namespace?: string;
   /** Line where the key was found */
-  line: number
-}
+  line: number;
+};
 
 type ExtractionResult = {
   /** Keys found during the extraction */
-  keys: Key[]
+  keys: Key[];
   /** Emitted warnings during the extraction */
-  warnings?: Warning[]
-}
+  warnings?: Warning[];
+};
 ```

--- a/tolgee-cli/extraction/magic-comments.mdx
+++ b/tolgee-cli/extraction/magic-comments.mdx
@@ -3,10 +3,6 @@ id: magic-comments
 title: Magic comments
 ---
 
-import Experimental from '../components/experimental.mdx'
-
-<Experimental/>
-
 In some cases, you may need to be explicit about what you want the extractor to do, because it's getting something wrong
 or because of a very specific use case. Magic comments to the rescue! They're a set of directives you can add to your
 code that'll explicitly tell the CLI what it should do.

--- a/tolgee-cli/extraction/magic-comments.mdx
+++ b/tolgee-cli/extraction/magic-comments.mdx
@@ -8,39 +8,46 @@ or because of a very specific use case. Magic comments to the rescue! They're a 
 code that'll explicitly tell the CLI what it should do.
 
 ## Usage
-As their name implies, they're written as comments. You probably already encountered some form of them with your code
+
+As their name implies, the magic comments are written as comments. You probably already encountered some form of them with your code
 linter, or type checker.
 
 Here is an example usage:
 
 ```jsx
-import React from 'react'
-import { T } from '@tolgee/react'
+import React from 'react';
+import { T } from '@tolgee/react';
 
-export default function MyComponent () {
+export default function MyComponent() {
   return (
     <section>
-      <h2><T keyName='section-title'>My title!</T></h2>
+      <h2>
+        <T keyName="section-title">My title!</T>
+      </h2>
       {/* @tolgee-ignore */}
-      <p><T keyName='section-text'>Section text!</T></p>
+      <p>
+        <T keyName="section-text">Section text!</T>
+      </p>
     </section>
-  )
+  );
 }
 ```
 
 Here, the `@tolgee-ignore` directive will tell the CLI to skip parsing the next line, and it will not include it in
-the extraction result. Only `section-title` would be considered a string.
+the extraction result. From the example above, only `section-title` would be considered a string.
 
 ## Available directives
+
 ### `@tolgee-ignore`
-Ignores the next line. Keys that might be present will not be extracted and warnings that would've been emitted will
-be suppressed as well.
+
+Ignores the next line. Keys that might be present will not be extracted and warnings, that would've been emitted, will be suppressed as well.
 
 :::info
 If the ignore directive does not have any effect, a warning will be emitted.
 :::
 
 ### `@tolgee-key`
+
 Specified a localization key. It can be written in 2 forms: simple or detailed.
 
 The simple form just takes the key name as an argument. The detailed form takes a JSON5 object, that takes the

--- a/tolgee-cli/extraction/syncing-strings.mdx
+++ b/tolgee-cli/extraction/syncing-strings.mdx
@@ -3,10 +3,6 @@ id: syncing-strings
 title: Syncing strings
 ---
 
-import Experimental from '../components/experimental.mdx'
-
-<Experimental/>
-
 :::info
 For the time being, only the React SDK is supported. See [issue #2](https://github.com/tolgee/tolgee-cli/issues/2)
 :::

--- a/tolgee-cli/extraction/syncing-strings.mdx
+++ b/tolgee-cli/extraction/syncing-strings.mdx
@@ -4,14 +4,14 @@ title: Syncing strings
 ---
 
 :::info
-For the time being, only the React SDK is supported. See [issue #2](https://github.com/tolgee/tolgee-cli/issues/2)
+For the time being, only the React SDK is supported. See [issue #2](https://github.com/tolgee/tolgee-cli/issues/2).
 :::
 
 The code extractor is a feature of the CLI that allows you not to worry about manually finding strings and adding them
 to the localization project, and leave this up to the CLI. No more stories about keys that have been forgotten!
 
 The CLI will look through your code project and look for usage of the [Tolgee SDK](/js-sdk), and give you all the keys
-used in your app. You'll then be able to push the missing keys to the platform, and deletes keys that have gone unused
+used in your app. You'll then be able to push the missing keys to the platform, and delete keys that have gone unused
 to keep your localization project clean.
 
 During analysis, the extractor will also look for [magic comments](/tolgee-cli/extraction/magic-comments) which are
@@ -22,13 +22,14 @@ and have the CLI handle the rest for you.
 
 :::tip
 Beware, glob patterns **will** conflict with your shell and **must be escaped**. If you don't wrap it as a string
-(e.g. `./src/**/*.tsx` instead of `"./src/**/*.tsx"`), your shell will attempt to process the `*` tokens and you will
+(e.g. `./src/**/*.tsx` instead of `'./src/**/*.tsx'`), your shell will attempt to process the `*` tokens and you will
 not have the results you're hoping for.
 :::
 
 ## Check for extraction warnings
+
 When extracting, the CLI might not be able to fully extract strings for a variety of reasons (e.g. dynamic data). When
-this happens, the CLI will emit a warning and tell you the file and line where this warning was emitted.
+this happens, the CLI emits a warning and tells you the file and line where this warning was emitted.
 
 ```
 tolgee extractor check [options] '[glob of files]'
@@ -38,21 +39,20 @@ Example usage:
 ```
 
 Options:
- - `--extractor` (short: `-e`): [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
-    to use the default internal extractor.
+
+- `--extractor` (short: `-e`) – [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
+  to use the default internal extractor.
 
 :::info
-In the future, when running this command on GitHub Actions, it will be able to add automated review annotation warnings
-directly in your commits and pull requests.
+When running this command on CI, the CLI automatically adds review annotation warnings directly in your commits and pull requests.
 
-Currently, it will only emit a workflow annotation you can see on the workflow summary.
-
-See [issue #20](https://github.com/tolgee/tolgee-cli/issues/20)
+See an example [here](https://github.com/tolgee/tolgee-platform/commit/ddfff41#diff-84dc9ca52993f2d66eda975f622361460f83d659ce6ddf1a0c086e6ca8c328ccR46).
 :::
 
 ## Comparing projects
+
 You can think of this utility as a dry-run of `tolgee sync`. You can use it to see the added/removed strings and
-see if what it tells you seems right, or if it got it somehow wrong.
+see if what it tells you seems right, or if it got something wrong.
 
 ```
 tolgee compare [options] '[glob of files]'
@@ -62,10 +62,12 @@ Example usage:
 ```
 
 Options:
- - `--extractor` (short: `-e`): [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
-    to use the default internal extractor.
+
+- `--extractor` (short: `-e`) – [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
+  to use the default internal extractor.
 
 ## Synchronizing projects
+
 ```
 tolgee sync [options] '[glob of files]'
 
@@ -74,19 +76,21 @@ Example usage:
 ```
 
 Options:
- - `--extractor` (short: `-e`): [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
-    to use the default internal extractor.
- - `--backup <path>` (short: `-B`): Optional. Path where a backup should be downloaded before performing the sync.
-    If something goes wrong, the backup can be used to restore the project to its previous state.
- - `--remove-unused`: Set this flag to also remove keys from the platform that are unused.
- - `--continue-on-warning`: Set this flag to continue the sync if warnings are detected during string extraction.
-    By default, as warnings may indicate an invalid extraction, the CLI will abort the sync.
- - `--yes` (short: `-Y`): Skip prompts and automatically say yes to them. You will not be asked for confirmation before
-    creating/deleting keys.
+
+- `--extractor` (short: `-e`) – [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
+  to use the default internal extractor.
+- `--backup <path>` (short: `-B`) – Optional. Path where a backup should be downloaded before performing the sync.
+  If something goes wrong, the backup can be used to restore the project to its previous state.
+- `--remove-unused` – Set this flag to also remove keys from the platform that are unused.
+- `--continue-on-warning` – Set this flag to continue the sync even if warnings are detected during string extraction.
+  By default, as warnings may indicate an invalid extraction, the CLI will abort the sync.
+- `--yes` (short: `-Y`) – Skip prompts and automatically say yes to them. You will not be asked for confirmation before
+  creating/deleting keys.
 
 ## Dumping all strings
+
 This is more of a debug command, which you can use to troubleshoot extraction issues, use as a way to test your
-[custom extractor](/tolgee-cli/extraction/custom-extractor), ...
+[custom extractor](/tolgee-cli/extraction/custom-extractor), etc.
 
 ```
 tolgee extract print [options] '[glob of files]'
@@ -96,5 +100,6 @@ Example usage:
 ```
 
 Options:
- - `--extractor` (short: `-e`): [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
-    to use the default internal extractor.
+
+- `--extractor` (short: `-e`) – [Custom extractor](/tolgee-cli/extraction/custom-extractor) to use. Leave unspecified
+  to use the default internal extractor.

--- a/tolgee-cli/installation.mdx
+++ b/tolgee-cli/installation.mdx
@@ -6,28 +6,19 @@ title: Installation
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import Experimental from './components/experimental.mdx'
-
-<Experimental/>
 
 The Tolgee CLI is written as a NodeJS program you can download via `npm`. You will need NodeJS version 18 or greater.
 Once installed, you'll have access to the `tolgee` command globally.
 
 <Tabs>
   <TabItem value="npm" label="NPM" default>
-    <CodeBlock language="bash">
-      npm install --global @tolgee/cli
-    </CodeBlock>
+    <CodeBlock language="bash">npm install --global @tolgee/cli</CodeBlock>
   </TabItem>
   <TabItem value="yarn" label="Yarn">
-    <CodeBlock language="bash">
-      yarn global add @tolgee/cli
-    </CodeBlock>
+    <CodeBlock language="bash">yarn global add @tolgee/cli</CodeBlock>
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
-    <CodeBlock language="bash">
-      pnpm add --global @tolgee/cli
-    </CodeBlock>
+    <CodeBlock language="bash">pnpm add --global @tolgee/cli</CodeBlock>
   </TabItem>
 </Tabs>
 

--- a/tolgee-cli/installation.mdx
+++ b/tolgee-cli/installation.mdx
@@ -7,11 +7,11 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
-The Tolgee CLI is written as a NodeJS program you can download via `npm`. You will need NodeJS version 18 or greater.
+The Tolgee CLI is written as a NodeJS program you can download via `npm`. You will need NodeJS version 18 or higher.
 Once installed, you'll have access to the `tolgee` command globally.
 
 <Tabs>
-  <TabItem value="npm" label="NPM" default>
+  <TabItem value="npm" label="npm" default>
     <CodeBlock language="bash">npm install --global @tolgee/cli</CodeBlock>
   </TabItem>
   <TabItem value="yarn" label="Yarn">
@@ -23,8 +23,8 @@ Once installed, you'll have access to the `tolgee` command globally.
 </Tabs>
 
 :::info
-You can also install the `@tolgee/cli` package in the current package only. You won't benefit from the global command,
+You can also install the `@tolgee/cli` package in the current project only. You won't benefit from the global command,
 and will have to use a package script (or `npx`) to run commands.
 
-You should make sure to save it as a dev dependency!
+You should make sure to install it as a dev dependency!
 :::

--- a/tolgee-cli/introduction.mdx
+++ b/tolgee-cli/introduction.mdx
@@ -4,40 +4,44 @@ title: Introduction to the CLI
 slug: /
 ---
 
-import Experimental from './components/experimental.mdx'
-
-<Experimental/>
-
 The Tolgee CLI is a command line utility created to make your life easier while using Tolgee, by allowing you to
 easily synchronize your code project with the translation project on Tolgee.
 
-<video loop autoPlay muted style={{ maxWidth: "100%", margin: "0 auto" }}>
+You can find the **source code** of the CLI on [GitHub](https://github.com/tolgee/tolgee-cli).
+
+<video loop autoPlay muted style={{ maxWidth: '100%', margin: '0 auto' }}>
   <source src="/tolgee-cli.webm"></source>
 </video>
 
 ## Features
+
 ### Easy project configuration
+
 Don't want to deal with having to type all project-specific options whenever invoking the CLI? No worries! You can
 create a [`.tolgeerc` file](/tolgee-cli/project-configuration) and not have to worry about specifying all these
 annoying options.
 
 ### Downloading & uploading strings
+
 You can easily download and upload localization files using the [`pull` and `push` commands](/tolgee-cli/push-pull-strings).
 
 Easily push new and updated strings to Tolgee when you're done working on a new feature, and automatically download all
 of the strings when building your app for production. It's really this easy!
 
 ### Extracting strings from your code
+
 One major feature of the CLI is the ability to scan your code for localization strings, and automagically extract them
 for you and sync them with the localization project.
 
 You can learn more about how it works [here](/tolgee-cli/extraction/syncing-strings).
 
 ### Work on your self-hosted server
+
 Not a fan of Service-as-a-Service and prefer to roll your own server? Or working locally? That's fine! You can very
 easily tell the CLI to talk to your Tolgee server.
 
 ### And more to come!
+
 We're working on constantly improving the CLI to make it even more powerful, just like the Tolgee Platform. Any idea
 for new features? We'd love to hear it! Make sure to send it to our [issue tracker](https://github.com/tolgee/tolgee-cli/issues/new)
 so we can start working on it.

--- a/tolgee-cli/introduction.mdx
+++ b/tolgee-cli/introduction.mdx
@@ -38,7 +38,7 @@ You can learn more about how it works [here](/tolgee-cli/extraction/syncing-stri
 ### Work on your self-hosted server
 
 Not a fan of Service-as-a-Service and prefer to roll your own server? Or working locally? That's fine! You can very
-easily tell the CLI to talk to your Tolgee server.
+easily tell the CLI to talk to your [self-hosted Tolgee server](/platform/self_hosting/getting_started).
 
 ### And more to come!
 

--- a/tolgee-cli/project-configuration.mdx
+++ b/tolgee-cli/project-configuration.mdx
@@ -23,13 +23,14 @@ You can also store your config in `package.json`, under the `tolgee` key.
 
 ### `projectId`
 
-Integer or integer string (i.e. 4242 or "4242"). ID of the project on the Tolgee server. It is printed when you first add an API key, but you can also easily find it in the url on the tolgee platform: `app.tolgee.io/projects/[projectId]`.
+Integer or integer string (i.e. 4242 or "4242"). ID of the project on the Tolgee server.
+It is shown when you first add an API key, but you can also easily find it in the URL: `app.tolgee.io/projects/{projectId}`.
 
 ### `delimiter`
 
-Single char, or null. Structure delimiter used.
+Single char, or null. Used as a structure delimiter.
 
-By default, Tolgee interprets `.` in string keys as nested structures. You can use another delimiter, or disable this
+By default, Tolgee interprets `.` in string keys as nested structures. You can use other delimiter, or disable this
 behavior by specifying `null`.
 
 ### `extractor`

--- a/tolgee-cli/project-configuration.mdx
+++ b/tolgee-cli/project-configuration.mdx
@@ -3,10 +3,6 @@ id: project-configuration
 title: Project configuration
 ---
 
-import Experimental from './components/experimental.mdx'
-
-<Experimental/>
-
 Rather than specifying project details every single time you run a command, you can set them once and forget about it
 by creating a `.tolgeerc` file. It will be parsed as a JSON file.
 
@@ -14,30 +10,35 @@ by creating a `.tolgeerc` file. It will be parsed as a JSON file.
 We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to parse the Toglee configuration file, which means
 you aren't limited to naming it `.tolgeerc`. You can use any of the following:
 
- - `.tolgeerc`
- - `.tolgeerc.[json|yaml|yml|js|cjs]`
- - `.config/tolgeerc`
- - `.config/tolgeerc.[json|yaml|yml|js|cjs]`
- - `tolgee.config.[js|cjs]`
+- `.tolgeerc`
+- `.tolgeerc.[json|yaml|yml|js|cjs]`
+- `.config/tolgeerc`
+- `.config/tolgeerc.[json|yaml|yml|js|cjs]`
+- `tolgee.config.[js|cjs]`
 
 You can also store your config in `package.json`, under the `tolgee` key.
 :::
 
 ## List of properties
+
 ### `projectId`
+
 Integer or integer string (i.e. 4242 or "4242"). ID of the project on the Tolgee server. It is printed when you first add an API key, but you can also easily find it in the url on the tolgee platform: `app.tolgee.io/projects/[projectId]`.
 
 ### `delimiter`
+
 Single char, or null. Structure delimiter used.
 
 By default, Tolgee interprets `.` in string keys as nested structures. You can use another delimiter, or disable this
 behavior by specifying `null`.
 
 ### `extractor`
+
 String. Path to the [custom extractor](/tolgee-cli/extraction/syncing-strings) to use, relative to the `.tolgeerc`
 file.
 
 By default, Tolgee uses its own internal extractor which looks for use of the [Tolgee SDK](/js-sdk).
 
 ### `apiUrl`
+
 String. URL to the Tolgee instance you're using. If you're using Tolgee Cloud, you can ignore this.

--- a/tolgee-cli/push-pull-strings.mdx
+++ b/tolgee-cli/push-pull-strings.mdx
@@ -9,7 +9,7 @@ it allows you to download strings from Tolgee to your computer (pull), or to upl
 ## Pulling strings
 
 This is a useful command that exports strings from the platform, and saves them in a folder of your choice. You can
-use this to download string from Tolgee before bundling your app for production.
+use this to download strings from Tolgee before bundling your app for production.
 
 ```
 tolgee pull [options] [destination folder]
@@ -20,14 +20,14 @@ Example usage:
 
 Options:
 
-- `--format <format>` (short: `-f`): Format of the exported files. Available formats: `xliff`, `json`. Defaults to `json`.
-- `--languages <languages...>` (short: `-l`): List of languages to pull. Leave unspecified to export them all
-- `--states <states...>` (short: `-s`): List of states to include. Available states: `untranslated`, `translated`,
+- `--format <format>` (short: `-f`) – Format of the exported files. Available formats: `xliff`, `json`. Defaults to `json`.
+- `--languages <languages...>` (short: `-l`) – List of languages to pull. Leave unspecified to export all languages.
+- `--states <states...>` (short: `-s`) – List of translation states to include. Available states: `untranslated`, `translated`,
   `reviewed`. Defaults to all except untranslated.
-- `--delimiter [delimiter]` (short: `-d`): Structure delimiter to use. By default, Tolgee treats `.` as a nested
+- `--delimiter [delimiter]` (short: `-d`) – Structure delimiter to use. By default, Tolgee treats `.` as a nested
   structure delimiter, and formats its export accordingly. Set the option without a value to disable this behavior.
   Can be [configured per-project](/tolgee-cli/project-configuration).
-- `--overwrite` (short: `-o`): Whether contents of the destination folder should be overridden. **This will erase
+- `--overwrite` (short: `-o`) – Whether contents of the destination folder should be overridden. **This will erase
   ALL of the contents of the destination folder**. Defaults to asking the user interactively (or failing if it is not
   possible).
 
@@ -40,6 +40,8 @@ See [issue #17](https://github.com/tolgee/tolgee-cli/issues/17).
 
 ## Pushing strings
 
+This command allows you to upload existing strings from your local folder to the platform.
+
 ```
 tolgee push [options] [translations folder]
 
@@ -49,11 +51,11 @@ Example usage:
 
 Options:
 
-- `--force-mode` (`-f`): Force mode. Available modes: `override`, `keep`, `no` (abort on conflicts). Defaults to
+- `--force-mode` (`-f`) – Force mode. Available modes: `override`, `keep`, `no` (abort on conflicts). Defaults to
   asking the user interactively (or `no` if it is not possible).
 
 :::tip
-For complex conflicts, even if the import failed you can still manually resolve the conflicts on the Tolgee webapp.
+For complex conflicts, even if the import fails, you can still manually resolve the conflicts in Tolgee itself.
 :::
 
 :::note

--- a/tolgee-cli/push-pull-strings.mdx
+++ b/tolgee-cli/push-pull-strings.mdx
@@ -3,14 +3,11 @@ id: push-pull-strings
 title: Pushing & pulling strings
 ---
 
-import Experimental from './components/experimental.mdx'
-
-<Experimental/>
-
 Pushing and pulling strings from Tolgee is the most basic way to interact with strings. Similarly as with a Git project,
 it allows you to download strings from Tolgee to your computer (pull), or to upload them after you changed them (push).
 
 ## Pulling strings
+
 This is a useful command that exports strings from the platform, and saves them in a folder of your choice. You can
 use this to download string from Tolgee before bundling your app for production.
 
@@ -22,16 +19,17 @@ Example usage:
 ```
 
 Options:
- - `--format <format>` (short: `-f`): Format of the exported files. Available formats: `xliff`, `json`. Defaults to `json`.
- - `--languages <languages...>` (short: `-l`): List of languages to pull. Leave unspecified to export them all
- - `--states <states...>` (short: `-s`): List of states to include. Available states: `untranslated`, `translated`,
-    `reviewed`. Defaults to all except untranslated.
- - `--delimiter [delimiter]` (short: `-d`): Structure delimiter to use. By default, Tolgee treats `.` as a nested
-    structure delimiter, and formats its export accordingly. Set the option without a value to disable this behavior.
-    Can be [configured per-project](/tolgee-cli/project-configuration).
- - `--overwrite` (short: `-o`): Whether contents of the destination folder should be overridden. **This will erase
-    ALL of the contents of the destination folder**. Defaults to asking the user interactively (or failing if it is not
-    possible).
+
+- `--format <format>` (short: `-f`): Format of the exported files. Available formats: `xliff`, `json`. Defaults to `json`.
+- `--languages <languages...>` (short: `-l`): List of languages to pull. Leave unspecified to export them all
+- `--states <states...>` (short: `-s`): List of states to include. Available states: `untranslated`, `translated`,
+  `reviewed`. Defaults to all except untranslated.
+- `--delimiter [delimiter]` (short: `-d`): Structure delimiter to use. By default, Tolgee treats `.` as a nested
+  structure delimiter, and formats its export accordingly. Set the option without a value to disable this behavior.
+  Can be [configured per-project](/tolgee-cli/project-configuration).
+- `--overwrite` (short: `-o`): Whether contents of the destination folder should be overridden. **This will erase
+  ALL of the contents of the destination folder**. Defaults to asking the user interactively (or failing if it is not
+  possible).
 
 :::note
 Currently, CLI does not let you pull only specific namespaces and will download all strings. In the near future, you'll
@@ -41,6 +39,7 @@ See [issue #17](https://github.com/tolgee/tolgee-cli/issues/17).
 :::
 
 ## Pushing strings
+
 ```
 tolgee push [options] [translations folder]
 
@@ -49,8 +48,9 @@ Example usage:
 ```
 
 Options:
- - `--force-mode` (`-f`): Force mode. Available modes: `override`, `keep`, `no` (abort on conflicts). Defaults to
-    asking the user interactively (or `no` if it is not possible).
+
+- `--force-mode` (`-f`): Force mode. Available modes: `override`, `keep`, `no` (abort on conflicts). Defaults to
+  asking the user interactively (or `no` if it is not possible).
 
 :::tip
 For complex conflicts, even if the import failed you can still manually resolve the conflicts on the Tolgee webapp.

--- a/tolgee-cli/usage.mdx
+++ b/tolgee-cli/usage.mdx
@@ -5,17 +5,17 @@ title: Usage
 
 Here is an overview of the basics of using the CLI.
 
-## Base options
+## Command options
 
 These options are available on all commands. They can be specified during the command execution, or configured once
 in a [per-project configuration](/tolgee-cli/project-configuration).
 
-- `--api-url <URL>` (short: `-au`) - URL of the Tolgee server. Useful for self-hosted installations. Can be [configured per-project](/tolgee-cli/project-configuration).
-- `--api-key <PAT/PAK>` (short: `-ak`) - **Required**. API Key. Can be a [Personal Access Token or a Project API Key](/platform/api-keys-and-pat-tokens).
-  May be omitted if you [logged in](#logging-in). You can also set it via the `TOLGEE_API_KEY` environment variable (recommended for CI server use).
-- `--project-id <ID>` (short: `-p`) - **Required**. Project ID on the Tolgee server. May be omitted if you explicitly
+- `--api-url <URL>` (short: `-au`) – URL of the Tolgee server. Useful for [self-hosted installations](/platform/self_hosting/getting_started). Can be [configured per-project](/tolgee-cli/project-configuration).
+- `--api-key <PAT/PAK>` (short: `-ak`) – **Required**. API Key. Can be a [Personal Access Token or a Project API Key](/platform/account_settings/api_keys_and_pat_tokens).
+  May be omitted if you are [logged in](#logging-in). You can also set it via the `TOLGEE_API_KEY` environment variable (recommended for CI server use).
+- `--project-id <ID>` (short: `-p`) – **Required**. Project ID on the Tolgee server. May be omitted if you explicitly
   specified a Project API Key via `--api-key` or `TOLGEE_API_KEY`. Can be [configured per-project](/tolgee-cli/project-configuration).
-- `--verbose` (short: `-v`) - Enables debug output.
+- `--verbose` (short: `-v`) – Enables debug output.
 
 :::tip
 When dealing with options that take multiple values, we recommend you put `--` at the end of the list of option values.
@@ -41,7 +41,7 @@ This makes sure the command parser will understand what you mean without any amb
 
 To interact with the Tolgee server, you need to authenticate yourself. For security reasons, the CLI doesn't use your
 username/password combo, but rather Personal Access Tokens, or Project API Keys. You can learn more about these
-on the [Tolgee Platform docs](/platform/api-keys-and-pat-tokens).
+on the [Tolgee Platform docs](/platform/account_settings/api_keys_and_pat_tokens).
 
 To make your life easier, the CLI allows you to store authentication tokens via `tolgee login` (and remove them via
 `tolgee logout`), so you don't have to specify your authentication tokens every single time.
@@ -52,17 +52,18 @@ To save your credentials, you simply need to run `tolgee login <token>`. The CLI
 is and save it appropriately. You can save multiple Project API Keys for different projects.
 
 :::info
-Here's how the CLI attempts to fetch the authentication token, from highest priority to lowest.
+Here's how the CLI attempts to fetch the authentication token, from highest priority to lowest:
 
-- `--api-key` option
-- `TOLGEE_API_KEY` environment variable
-- Personal Access Token saved in credentials store
-- Project API Key saved in credentials store
-  :::
+1. `--api-key` option
+2. `TOLGEE_API_KEY` environment variable
+3. Personal Access Token saved in credentials store
+4. Project API Key saved in credentials store
+
+:::
 
 ### Using a self-hosted instance
 
-If you are not hosting your project on Tolgee Cloud, you can configure this in the [`.tolgeerc`](/tolgee-cli/project-configuration#apiUrl)
+If you are not using Tolgee Cloud, but you are running a [self-hosted instance](/platform/self_hosting/getting_started) instead, you can configure this in the [`.tolgeerc`](/tolgee-cli/project-configuration#apiUrl)
 file for a whole project, or specify it when running commands via the `--api-url` flag.
 
 When running `tolgee login` in a project configured to use a different instance, Tolgee will automatically attempt to

--- a/tolgee-cli/usage.mdx
+++ b/tolgee-cli/usage.mdx
@@ -3,27 +3,24 @@ id: usage
 title: Usage
 ---
 
-import Experimental from './components/experimental.mdx'
-
-<Experimental/>
-
 Here is an overview of the basics of using the CLI.
 
 ## Base options
+
 These options are available on all commands. They can be specified during the command execution, or configured once
 in a [per-project configuration](/tolgee-cli/project-configuration).
 
- - `--api-url <URL>` (short: `-au`) - URL of the Tolgee server. Useful for self-hosted installations. Can be [configured per-project](/tolgee-cli/project-configuration).
- - `--api-key <PAT/PAK>` (short: `-ak`) - **Required**. API Key. Can be a [Personal Access Token or a Project API Key](/platform/api-keys-and-pat-tokens).
-    May be omitted if you [logged in](#logging-in). You can also set it via the `TOLGEE_API_KEY` environment variable
-    (recommended for CI server use).
- - `--project-id <ID>` (short: `-p`) - **Required**. Project ID on the Tolgee server. May be omitted if you explicitly
-    specified a Project API Key via `--api-key` or `TOLGEE_API_KEY`. Can be [configured per-project](/tolgee-cli/project-configuration).
- - `--verbose` (short: `-v`) - Enables debug output.
+- `--api-url <URL>` (short: `-au`) - URL of the Tolgee server. Useful for self-hosted installations. Can be [configured per-project](/tolgee-cli/project-configuration).
+- `--api-key <PAT/PAK>` (short: `-ak`) - **Required**. API Key. Can be a [Personal Access Token or a Project API Key](/platform/api-keys-and-pat-tokens).
+  May be omitted if you [logged in](#logging-in). You can also set it via the `TOLGEE_API_KEY` environment variable (recommended for CI server use).
+- `--project-id <ID>` (short: `-p`) - **Required**. Project ID on the Tolgee server. May be omitted if you explicitly
+  specified a Project API Key via `--api-key` or `TOLGEE_API_KEY`. Can be [configured per-project](/tolgee-cli/project-configuration).
+- `--verbose` (short: `-v`) - Enables debug output.
 
 :::tip
 When dealing with options that take multiple values, we recommend you put `--` at the end of the list of option values.
 For instance, let's take this command as an example:
+
 ```
 tolgee some-command [options] [path]
 
@@ -32,6 +29,7 @@ Options:
 ```
 
 We recommend writing the command like so:
+
 ```
 tolgee some-command --languages en cz fr -- example/path
 ```
@@ -40,6 +38,7 @@ This makes sure the command parser will understand what you mean without any amb
 :::
 
 ## Logging in
+
 To interact with the Tolgee server, you need to authenticate yourself. For security reasons, the CLI doesn't use your
 username/password combo, but rather Personal Access Tokens, or Project API Keys. You can learn more about these
 on the [Tolgee Platform docs](/platform/api-keys-and-pat-tokens).
@@ -48,18 +47,21 @@ To make your life easier, the CLI allows you to store authentication tokens via 
 `tolgee logout`), so you don't have to specify your authentication tokens every single time.
 
 ### Saving credentials
+
 To save your credentials, you simply need to run `tolgee login <token>`. The CLI will figure out what type of token it
 is and save it appropriately. You can save multiple Project API Keys for different projects.
 
 :::info
 Here's how the CLI attempts to fetch the authentication token, from highest priority to lowest.
- - `--api-key` option
- - `TOLGEE_API_KEY` environment variable
- - Personal Access Token saved in credentials store
- - Project API Key saved in credentials store
-:::
+
+- `--api-key` option
+- `TOLGEE_API_KEY` environment variable
+- Personal Access Token saved in credentials store
+- Project API Key saved in credentials store
+  :::
 
 ### Using a self-hosted instance
+
 If you are not hosting your project on Tolgee Cloud, you can configure this in the [`.tolgeerc`](/tolgee-cli/project-configuration#apiUrl)
 file for a whole project, or specify it when running commands via the `--api-url` flag.
 


### PR DESCRIPTION
This PR removes mentions of the CLI being "experimental" from the documentation and adds link to the GitHub repo to the Introduction guide.

I have also reviewed the CLI documentation and fixed all internal links that were broken by #391.