### PR TITLE
fix: Typo in Tolgee CLI docs

### DIFF
--- a/tolgee-cli/extraction/custom-extractor.mdx
+++ b/tolgee-cli/extraction/custom-extractor.mdx
@@ -39,7 +39,7 @@ file.
 :::
 
 :::tip
-[`tolgee extractor print`](/tolgee-cli/extraction/syncing-strings#dumping-all-strings) is a very helpful command to
+[`tolgee extract print`](/tolgee-cli/extraction/syncing-strings#dumping-all-strings) is a very helpful command to
 test and troubleshoot your extractor. It will dump all the keys it found and the warnings emitted to the console.
 :::
 

--- a/tolgee-cli/extraction/syncing-strings.mdx
+++ b/tolgee-cli/extraction/syncing-strings.mdx
@@ -32,10 +32,10 @@ When extracting, the CLI might not be able to fully extract strings for a variet
 this happens, the CLI emits a warning and tells you the file and line where this warning was emitted.
 
 ```
-tolgee extractor check [options] '[glob of files]'
+tolgee extract check [options] '[glob of files]'
 
 Example usage:
-   tolgee extractor check './src/**/*.ts?(x)'
+   tolgee extract check './src/**/*.ts?(x)'
 ```
 
 Options:


### PR DESCRIPTION
This PR fixes a typo in Tolgee CLI documentation.