### PR TITLE
docs(cli): mark that glob arguments can take multiple values

### DIFF
--- a/tolgee-cli/extraction/syncing-strings.mdx
+++ b/tolgee-cli/extraction/syncing-strings.mdx
@@ -32,7 +32,7 @@ When extracting, the CLI might not be able to fully extract strings for a variet
 this happens, the CLI emits a warning and tells you the file and line where this warning was emitted.
 
 ```
-tolgee extract check [options] '[glob of files]'
+tolgee extract check [options] ['glob of files'...]
 
 Example usage:
    tolgee extract check './src/**/*.ts?(x)'
@@ -55,7 +55,7 @@ You can think of this utility as a dry-run of `tolgee sync`. You can use it to s
 see if what it tells you seems right, or if it got something wrong.
 
 ```
-tolgee compare [options] '[glob of files]'
+tolgee compare [options] ['glob of files'...]
 
 Example usage:
    tolgee compare './src/**/*.ts?(x)'
@@ -69,7 +69,7 @@ Options:
 ## Synchronizing projects
 
 ```
-tolgee sync [options] '[glob of files]'
+tolgee sync [options] ['glob of files'...]
 
 Example usage:
    tolgee sync './src/**/*.ts?(x)'
@@ -93,7 +93,7 @@ This is more of a debug command, which you can use to troubleshoot extraction is
 [custom extractor](/tolgee-cli/extraction/custom-extractor), etc.
 
 ```
-tolgee extract print [options] '[glob of files]'
+tolgee extract print [options] ['glob of files'...]
 
 Example usage:
    tolgee extract print './src/**/*.ts?(x)'


### PR DESCRIPTION
Hey There 👋 

This a sibling PR for https://github.com/tolgee/tolgee-cli/pull/69.

I wasn't sure about what's the best way to document that the glob argument can now accept multiple values. I had multiple ideas:

a) show multiple example commands
![image](https://github.com/tolgee/documentation/assets/31937175/17db006d-819d-4a7c-be3c-ef010b521ff1)

---

b) document the argument below the code example
![image](https://github.com/tolgee/documentation/assets/31937175/134fa7cb-0e2c-41e2-a3cc-d55a91316709)

---

c) Use `...` in the examples, like in the [Commander docs](https://github.com/tj/commander.js?tab=readme-ov-file#variadic-option)
![image](https://github.com/tolgee/documentation/assets/31937175/541edf57-bfea-4a82-9bfb-5ab7ff8e98c6)

---

I went with `c`, because `a` felt too repetitive for every example and `b` looked weird, because I haven't seen arguments documented for other commands. I'm open for suggestions and opinions though:D