### PR TITLE
docs(integrations): update next.js app router example link

### DIFF
--- a/js-sdk/integrations/react/next/app_router.mdx
+++ b/js-sdk/integrations/react/next/app_router.mdx
@@ -5,7 +5,7 @@ title: Next.js with app router
 description: 'Learn how to integrate Tolgee with Next.js and app router, while still use in-context translating and dev tools.'
 ---
 
-To see the full working code, check the [Example app](https://github.com/tolgee/next-example).
+To see the full working code, check the [Example app](https://github.com/tolgee/next-app-example).
 
 ## Installation
 


### PR DESCRIPTION
Just a small change. The current link in the app router integration page points to the example that uses the pages router.