### PR TITLE
docs(integrations): link directly to the next.js app router docs

### DIFF
--- a/src/pages/integrations/next.tsx
+++ b/src/pages/integrations/next.tsx
@@ -52,9 +52,9 @@ export default function Next() {
       </LandingPageHeadline>
       <div className="container integration">
         <Alert severity="info">
-          Read about Next.js App router on{' '}
-          <Link href="/blog/how-to-setup-tolgee-with-nextjs-app-router">
-            our blog
+          Read about Next.js App router in{' '}
+          <Link href="/js-sdk/integrations/react/next/app-router">
+            our documentation
           </Link>
         </Alert>
       </div>


### PR DESCRIPTION
On the Next.js integration page, the current link about the app router points to a blog post that is outdated. This PR changes the link to point directly to the documentation about the app router integration.

![image](https://github.com/tolgee/documentation/assets/31937175/04504c9f-1a7a-42a2-a04b-f8577af98a50)
