### PR TITLE
fix: repair some broken doc links in about_tolgee.mdx

### DIFF
--- a/platform/getting_started/about_tolgee.mdx
+++ b/platform/getting_started/about_tolgee.mdx
@@ -17,14 +17,14 @@ No more looking for keys in your source code, no more editing localization files
 
 - **Developer-friendly** - Tolgee is designed to be easy to integrate with your application. There are number of integrations with JavaScript frameworks, such as React, Angular, Vue, and many more with the use of [Tolgee JS SDK](/js-sdk).
 - **Easy to use** - Tolgee is easy to use for developers, but also for translators, so you can easily involve your translators into your localization process.
-- **Open-source** - Tolgee is open-source, you can contribute to the project on our [GitHub repository](https://github.com/tolgee/tolgee-platform). You can also [host your own instance](/self_hosting/getting_started) of Tolgee, so you can have full control over your data.
+- **Open-source** - Tolgee is open-source, you can contribute to the project on our [GitHub repository](https://github.com/tolgee/tolgee-platform). You can also [host your own instance](/platform/self_hosting/getting_started) of Tolgee, so you can have full control over your data.
 - **Free** - Our **cloud version** includes Business plan with 20 000 strings is **free for any open-source projects**. For commercial projects, you can use Tolgee for free up to 1000 strings. For more information, see [pricing](/pricing).
 - **In-context editor** - Tolgee provides in-context editor, so translators can easily translate your application without leaving your application.
 - **Tolgee AI translator** — [Tolgee Translator](/platform/translation_process/tolgee_translator) can make software localization much faster and more autonomous. It provides more accurate translations than general translators as it gathers context through Tolgee's native JS SDKs, which provide in-context dialogs.
 
 ## Intrigued yet?
 
-If you want to try Tolgee, you can [sign up](https://app.tolgee.io/sign_up) for free and start using it right away. After you sign up, you will be able to [create your first project](getting_started/creating_project) and start translating your application.
+If you want to try Tolgee, you can [sign up](https://app.tolgee.io/sign_up) for free and start using it right away. After you sign up, you will be able to [create your first project](/platform/getting_started/creating_project) and start translating your application.
 
 ## Other Tolgee Docs
 


### PR DESCRIPTION
note: this is not an exhaustive update, as I have not checked every page in the docs.. but as the "landing page" for the Platform docs, it is one that almost everyone will visit at some point.