### PR TITLE
fix: Temporary fix for `pricing` relative link

### DIFF
--- a/platform/self_hosting/configuration.mdx
+++ b/platform/self_hosting/configuration.mdx
@@ -495,7 +495,7 @@ Configuration of Machine Translation services.
 
 - ##### `free-credits-amount` {#free-credits-amount}
 
-  Amount of machine translations users of the Free tier can request per month. Used by Tolgee Cloud, see [pricing](/pricing). Set to `-1` to disable credit-based limitation. (default: `-1`)
+  Amount of machine translations users of the Free tier can request per month. Used by Tolgee Cloud, see [pricing](https://tolgee.io/pricing). Set to `-1` to disable credit-based limitation. (default: `-1`)
 
 #### AWS Amazon Translate
 


### PR DESCRIPTION
This will be properly fixed by tolgee/tolgee-platform#2702 to make the change permanent for the automatic doc generation from the code itself