### PR TITLE
Change forceMode from OVERRIDE to NO_FORCE

### DIFF
--- a/tolgee-cli/project-configuration.mdx
+++ b/tolgee-cli/project-configuration.mdx
@@ -18,7 +18,7 @@ Example configuration:
       "path": "./public/i18n/en.json",
       "language": "en"
     }],
-    "forceMode": "OVERRIDE",
+    "forceMode": "NO_FORCE",
   },
   "pull": {
     "path": "./public/i18n"


### PR DESCRIPTION
Using the default value `OVERRIDE` for `forceMode` can lead to unintended data loss, as it overrides without explicit confirmation. I overlooked this configuration, which unfortunately caused the loss of two days' work by a co-worker. This change sets `forceMode` to `NO_FORCE`, aligning with safer practices to prevent such issues in the future.