### PR TITLE
fix: broken links when trailing slash is missing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,11 +45,11 @@ const config = {
   },
   presets: [
     [
-      "classic",
+      'classic',
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          docItemComponent: "@theme/ApiItem", // Derived from docusaurus-theme-openapi
+          docItemComponent: '@theme/ApiItem', // Derived from docusaurus-theme-openapi
           editUrl: 'https://github.com/tolgee/documentation/tree/main',
         },
         blog: {
@@ -64,9 +64,9 @@ const config = {
           archiveBasePath: null,
         },
         theme: {
-          customCss: "./src/css/custom.css",
+          customCss: './src/css/custom.css',
         },
-      }
+      },
     ],
   ],
   plugins: [
@@ -106,7 +106,8 @@ const config = {
       async: true,
     },
   ],
-  onBrokenAnchors: 'throw'
+  onBrokenAnchors: 'throw',
+  trailingSlash: false,
 };
 
 module.exports = config;

--- a/js-sdk/about.mdx
+++ b/js-sdk/about.mdx
@@ -7,12 +7,12 @@ description: 'Tolgee SDK provides the functionality of an i18n library and helps
 
 import { ScreenRecording } from '../platform/shared/_ScreenRecording';
 
-Tolgee SDK provides the functionality of an i18n library and helps you with [formatting](./formatting), interpolation, and [language detection](./language#language-detection).
-The SDK also allows you to connect to the [Tolgee Platform](../platform/). It enables you to implement [in-context translation](./in-context) which also helps you generate one-click screenshots and edit translations directly in your app.
+Tolgee SDK provides the functionality of an i18n library and helps you with [formatting](./formatting.mdx), interpolation, and [language detection](./language.mdx#language-detection).
+The SDK also allows you to connect to the [Tolgee Platform](../platform/). It enables you to implement [in-context translation](./in_context.mdx) which also helps you generate one-click screenshots and edit translations directly in your app.
 
 ## In-context Translation
 
-In-context translation helps you speed up development by saving you from tedious localization tasks. Using the Tolgee SDK, you can implement in-context translation. Learn more about in-context translation and how to implement it in your local development environment in [this documentation](./in-context).
+In-context translation helps you speed up development by saving you from tedious localization tasks. Using the Tolgee SDK, you can implement in-context translation. Learn more about in-context translation and how to implement it in your local development environment in [this documentation](./in_context.mdx).
 
 <ScreenRecording>
   <source src="/in-context.mov"></source>


### PR DESCRIPTION
`trailingSlash: false` threw the correct errors about broken links and when imported with the `.mdx` extension, it works correctly. Not sure why it was broken, however this seems to fix the problem