### PR TITLE
docs: update Next.js integration guides with @tolgee/web dependency and simplified language list

### DIFF
--- a/js-sdk/integrations/react/next/app_router.mdx
+++ b/js-sdk/integrations/react/next/app_router.mdx
@@ -10,7 +10,6 @@ import ExampleBanner from '../../../shared/ExampleBanner';
 import LimitationsOfServerComponents from './shared/_LimitationsOfServerComponents.mdx'
 import CdnFetchPlugin from './shared/_CdnFetchPlugin.mdx';
 
-
 <ExampleBanner framework="Next app router" appName="next-app" />
 
 Follow the below instructions to learn to implement localization to your Next.js App Router app with Tolgee.
@@ -26,11 +25,11 @@ In this example we'll store language in cookies, which is a simple to implement,
 
 ## Install the required packages
 
-To implement localization to your app, you need to install the `@tolgee/react` package:
+To implement localization to your app, you need to install the `@tolgee/react` and `@tolgee/web` package:
 
-```sh
-npm install @tolgee/react
-```
+import { InstallationTabs } from '../../../../src/component/InstallationTabs';
+
+<InstallationTabs lib="@tolgee/react @tolgee/web" />
 
 ## Folder structure
 

--- a/js-sdk/integrations/react/next/app_router_next_intl.mdx
+++ b/js-sdk/integrations/react/next/app_router_next_intl.mdx
@@ -31,11 +31,11 @@ Follow the below instructions to learn to implement localization to your Next.js
 
 ## Install the required packages
 
-To implement localization to your app, you need to install the `next-intl` and `@tolgee/react` package. Execute the following command to install the package.
+To implement localization to your app, you need to install the `next-intl`, `@tolgee/react` and `@tolgee/web` package. Execute the following command to install the package.
 
-```sh
-npm install next-intl @tolgee/react
-```
+import { InstallationTabs } from '../../../../src/component/InstallationTabs';
+
+<InstallationTabs lib="next-intl @tolgee/react @tolgee/web" />
 
 ## Folder structure
 
@@ -92,7 +92,7 @@ import { DevTools, Tolgee, FormatSimple } from '@tolgee/web';
 const apiKey = process.env.NEXT_PUBLIC_TOLGEE_API_KEY;
 const apiUrl = process.env.NEXT_PUBLIC_TOLGEE_API_URL;
 
-export const ALL_LANGUAGES = ['en', 'cs', 'de', 'fr'];
+export const ALL_LANGUAGES = ['en', 'cs'];
 
 export const DEFAULT_LANGUAGE = 'en';
 
@@ -117,7 +117,7 @@ The client configuration is very similar to the [Pages Router set up](./pages-ro
 'use client';
 
 import { useEffect } from 'react';
-import { TolgeeProvider, TolgeeStaticData } from '@tolgee/react';
+import { CachePublicRecord, TolgeeProvider, TolgeeStaticData } from '@tolgee/react';
 import { useRouter } from 'next/navigation';
 import { TolgeeBase } from './shared';
 

--- a/js-sdk_versioned_docs/version-5.x.x/integrations/react/next/app_router_next_intl.mdx
+++ b/js-sdk_versioned_docs/version-5.x.x/integrations/react/next/app_router_next_intl.mdx
@@ -95,7 +95,7 @@ import { DevTools, Tolgee, FormatSimple } from '@tolgee/web';
 const apiKey = process.env.NEXT_PUBLIC_TOLGEE_API_KEY;
 const apiUrl = process.env.NEXT_PUBLIC_TOLGEE_API_URL;
 
-export const ALL_LANGUAGES = ['en', 'cs', 'de', 'fr'];
+export const ALL_LANGUAGES = ['en', 'cs'];
 
 export const DEFAULT_LANGUAGE = 'en';
 


### PR DESCRIPTION
- Added @tolgee/web as a required dependency in the Next.js integration guide
- Simplified the language list configuration example
- Improved clarity and structure of integration steps