### PR TITLE
docs: fix code block

### DIFF
--- a/js-sdk/integrations/react/next/app_router_next_intl.mdx
+++ b/js-sdk/integrations/react/next/app_router_next_intl.mdx
@@ -252,7 +252,8 @@ import { ALL_LANGUAGES } from './tolgee/shared';
 // https://next-intl-docs.vercel.app
 export const { Link, redirect, usePathname, useRouter } = createNavigation({
   locales: ALL_LANGUAGES,
-});```
+});
+```
 
 > To gain a comprehensive understanding of how `next-intl` operates, read [their documentation](https://next-intl-docs.vercel.app/docs/getting-started/app-router-server-components). This example utilizes the necessary setup for proper routing. Not all the listed configurations are required.
 


### PR DESCRIPTION
Currently there is a mistake in the docs, causing markdown to render incorrectly. This small patch fixes that.

Image of the issue:

<img width="928" height="700" alt="Screenshot 2025-08-20 at 15 34 26" src="https://github.com/user-attachments/assets/0f6bb766-aa7a-487f-a816-ed8fe1364345" />

(The `> To gain a comprehensive understanding of how ...` section should be rendered as mardown)