### PR TITLE
chore: update image format to webp and add spacing in CSS wrapper

### DIFF
--- a/platform/shared/_ScreenWrapper.css
+++ b/platform/shared/_ScreenWrapper.css
@@ -5,6 +5,7 @@
   display: inline-grid;
   overflow: hidden;
 }
+
 .screen-wrapper--container img {
   max-width: 100%;
   width: auto;

--- a/platform/translation_process/ai_translator.mdx
+++ b/platform/translation_process/ai_translator.mdx
@@ -19,7 +19,7 @@ Tolgee Context is a statistic about relations between the keys based on how they
 Context is gathered by Tolgee SDK. [Read more.](/js-sdk#automatic-context-collection)
 
 <ScreenshotWrapper
-  src="/img/docs/platform/ai-translator.png"
+  src="/img/docs/platform/ai-translator.webp"
   alt="AI Translator"
 />
 


### PR DESCRIPTION
I discovered that one of the documents' images was in an outdated PNG format and wasn't showing up correctly.