### PR TITLE
chore: Fixed links to OSS friends

### DIFF
--- a/src/pages/oss-friends/index.tsx
+++ b/src/pages/oss-friends/index.tsx
@@ -29,12 +29,12 @@ export default function OssFriends() {
           .filter(({ name }) => name !== 'Tolgee')
           .map(({ name, description, href }, i) => (
             <div key={i} className="oss-friends--friend">
-              <Link to={href}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
                 <Heading as="h3">{name}</Heading>
-              </Link>
+              </a>
               <div>{description}</div>
               <div className="oss-friends--friend-learn-more">
-                <Link to={href}>Learn more</Link>
+                <a href={href} target="_blank" rel="noopener noreferrer">Learn more</a>
               </div>
             </div>
           ))}


### PR DESCRIPTION
The links on [https://docs.tolgee.io/oss-friends](https://docs.tolgee.io/oss-friends) were leading to broken pages with the URL like: https://docs.tolgee.io/https://activepieces.com

Now it opens the websites properly

P.S. I am not sure if the "rel" attribute in the links should be what it is, as I am not aware of what conditions the links are kept there in the docs. Maybe they need to be dofollow?