### PR TITLE
docs: clarify AI Translator uses LLMs, not just ChatGPT

### DIFF
--- a/js-sdk/about.mdx
+++ b/js-sdk/about.mdx
@@ -37,7 +37,7 @@ To help translators understand context, you can add screenshots. Capture them in
 
 ## Automatic Context Collection
 
-The SDK automatically collects additional context about the layout of the keys on the page. This context allows the AI Translator to provide you with better results, utilizing ChatGPT under the hood.
+The SDK automatically collects additional context about the layout of the keys on the page. This context allows the AI Translator to provide you with better results, using large language models under the hood.
 
 ### What data are collected and when?
 

--- a/js-sdk_versioned_docs/version-5.x.x/about.mdx
+++ b/js-sdk_versioned_docs/version-5.x.x/about.mdx
@@ -34,7 +34,7 @@ To help translators understand the exact context of the translation, you can now
 
 ## Automatic Context Collection
 
-The SDK automatically collects additional context about the layout of the keys on the page. This context allows the Tolgee Translator to provide you with better results, utilizing ChatGPT under the hood.
+The SDK automatically collects additional context about the layout of the keys on the page. This context allows the Tolgee Translator to provide you with better results, using large language models under the hood.
 
 ### What data are collected and when?
 

--- a/platform/projects_and_organizations/machine_translation_settings.mdx
+++ b/platform/projects_and_organizations/machine_translation_settings.mdx
@@ -12,7 +12,7 @@ Number of machine translations that you can use is limited by credits which are 
 ## Supported Machine Translation Providers
 Currently, we support the following machine translation providers:
 
-- Tolgee AI translation with context based on ChatGPT translation
+- Tolgee AI translation with context (powered by LLMs — see [AI Translator](/platform/translation_process/ai_translator))
 - Google Translate integration
 - Amazon Translate (AWS)
 - DeepL integration

--- a/platform/translation_process/ai_translator.mdx
+++ b/platform/translation_process/ai_translator.mdx
@@ -1,14 +1,18 @@
 ---
 id: ai_translator
 title: AI Translator
-description: AI Translator is based on ChatGPT and can translate with included Tolgee Context, key description, project description, language notes and results from TM.
+description: Tolgee AI Translator is powered by large language models and can translate with included Tolgee Context, key description, project description, language notes and results from TM.
 image: /img/og-images/machine-translation.png
 ---
 
 import { ScreenshotWrapper } from '../shared/_ScreenshotWrapper';
 
-AI Translator is based on ChatGPT and can translate with included screenshots, [Tolgee Context](/js-sdk#automatic-context-collection),
+Tolgee AI Translator is powered by large language models (LLMs) and can translate with included screenshots, [Tolgee Context](/js-sdk#automatic-context-collection),
 key description, project description, language notes and results from the translation memory.
+
+On Tolgee Cloud, the AI Translator natively uses Anthropic Claude and OpenAI (ChatGPT) models. You can also configure your own
+[LLM providers](/platform/projects_and_organizations/llm-providers) — both on Tolgee Cloud (per organization) and when self-hosting — including OpenAI,
+Azure OpenAI, Anthropic Claude, Google AI (Gemini), or any OpenAI-compatible API such as LM Studio.
 
 ## AI Translator with context
 


### PR DESCRIPTION
## Problem

The documentation stated that the AI Translator is "based on ChatGPT". That's not accurate — the AI Translator is powered by large language models, users can bring their own services, and Tolgee supports several provider APIs. On Tolgee Cloud, it natively uses Anthropic Claude and OpenAI (ChatGPT) models.

## Changes

- **`platform/translation_process/ai_translator.mdx`** — reworded the description and intro to say it's powered by LLMs; added a paragraph explaining native Cloud models (Anthropic Claude + OpenAI) and custom LLM providers (Cloud per-org and self-hosted), linking to the LLM providers page.
- **`platform/projects_and_organizations/machine_translation_settings.mdx`** — "Tolgee AI translation with context based on ChatGPT translation" → "powered by LLMs", linking to the AI Translator page.
- **`js-sdk/about.mdx`** and **`js-sdk_versioned_docs/version-5.x.x/about.mdx`** — "utilizing ChatGPT under the hood" → "using large language models under the hood".

Left untouched: the `OpenAi (ChatGPT)` provider-type heading in `llm_providers.mdx` (accurate — it's the OpenAI API type), the `OpenAi playground` UI button references, and ChatGPT listed as an MCP client.