### PR TITLE
docs: use "plural form" consistently in QA checks page

### DIFF
--- a/platform/translation_process/qa_checks.mdx
+++ b/platform/translation_process/qa_checks.mdx
@@ -220,4 +220,4 @@ Checks are also automatically re-run when the base language translation changes,
 
 ### Plural Translations
 
-For translations that use plural forms, QA checks run separately on each plural variant. Issues are reported per variant, so you can see exactly which form has the problem.
+For translations that use plural forms, QA checks run separately on each plural form. Issues are reported per form, so you can see exactly which form has the problem.


### PR DESCRIPTION
## Summary

- Replace the lone "plural variant" / "per variant" wording on the QA checks page with "plural form", matching the term used everywhere else in the docs and the platform UI.