### PR TITLE
docs(apps): Tolgee Apps documentation (alpha)

### DIFF
--- a/docs.js
+++ b/docs.js
@@ -91,6 +91,24 @@ const docs = [
   [
     '@docusaurus/plugin-content-docs',
     {
+      id: 'tolgee-apps',
+      path: 'tolgee-apps',
+      routeBasePath: 'apps',
+      sidebarPath: require.resolve('./sidebarTolgeeApps.js'),
+      lastVersion: 'current',
+      includeCurrentVersion: true,
+      editUrl: 'https://github.com/tolgee/documentation/tree/main',
+      versions: {
+        current: {
+          banner: 'none',
+          label: 'alpha',
+        },
+      },
+    },
+  ],
+  [
+    '@docusaurus/plugin-content-docs',
+    {
       id: 'rest-api',
       path: 'api',
       breadcrumbs: true,

--- a/docs.js
+++ b/docs.js
@@ -97,6 +97,7 @@ const docs = [
       sidebarPath: require.resolve('./sidebarTolgeeApps.js'),
       lastVersion: 'current',
       includeCurrentVersion: true,
+      showLastUpdateTime: true,
       editUrl: 'https://github.com/tolgee/documentation/tree/main',
       versions: {
         current: {

--- a/navbar.js
+++ b/navbar.js
@@ -36,6 +36,10 @@ module.exports.navbar = {
       label: 'CLI',
     },
     {
+      to: 'apps/intro',
+      label: 'Apps',
+    },
+    {
       to: 'api',
       label: 'REST API',
     },

--- a/sidebarTolgeeApps.js
+++ b/sidebarTolgeeApps.js
@@ -1,0 +1,13 @@
+module.exports = {
+  someSidebar: [
+    'intro',
+    'setup',
+    'api',
+    {
+      label: 'Tutorials',
+      collapsed: false,
+      type: 'category',
+      items: ['tutorial-activity-monitoring', 'tutorial-back-translation'],
+    },
+  ],
+};

--- a/tolgee-apps/api.mdx
+++ b/tolgee-apps/api.mdx
@@ -69,7 +69,11 @@ type AppIframeModule = {
 };
 ```
 
-Used by: `project-dashboard-page`, `translation-tools-panel`, `key-edit-tab`, `modal`.
+Used by: `project-dashboard-page`, `translation-tools-panel`, `translation-tools-panel-empty`, `key-edit-tab`, `modal`.
+
+`translation-tools-panel-empty` renders in the translations tools area when **no cell is
+selected**. Instead of a key/language selection it receives the view's selected language tags via
+`selection.selectedLanguages`, which updates as the user changes the language selector.
 
 Action modules are triggers; they don't render their own page but point at an iframe module or a link:
 
@@ -150,6 +154,7 @@ type TolgeeAppSelection = {
   languageId?: number;
   languageTag?: string;
   translationId?: number;
+  selectedLanguages?: string[];   // tags shown in the view (translation-tools-panel-empty only)
 };
 ```
 
@@ -199,7 +204,7 @@ If you don't use the SDK, the iframe ↔ host messages are:
 | --- | --- | --- |
 | iframe → host | `tolgee-app:ready` | — (signals the iframe is listening) |
 | host → iframe | `tolgee-app:init` | `{ token, apiUrl, organizationId, projectId, selection…, extra… }` |
-| host → iframe | `tolgee-app:selection-changed` | `{ keyId?, languageId?, languageTag?, translationId? }` |
+| host → iframe | `tolgee-app:selection-changed` | `{ keyId?, languageId?, languageTag?, translationId?, selectedLanguages? }` |
 | iframe → host | `tolgee-app:resize` | `{ height }` |
 | iframe → host | `tolgee-app:close` | — |
 
@@ -349,7 +354,7 @@ Both read `.env.local` (`TOLGEE_URL`, ports) and the install record at `.tolgee-
           name: 'Which Tolgee App manifest modules render an iframe?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'project-dashboard-page, translation-tools-panel, key-edit-tab, and modal render an iframe from your baseUrl. The action modules (key-action, translation-action, bulk-action, translations-toolbar-action, project-menu-action, shortcut) are triggers configured entirely in the manifest.',
+            text: 'project-dashboard-page, translation-tools-panel, translation-tools-panel-empty, key-edit-tab, and modal render an iframe from your baseUrl. The action modules (key-action, translation-action, bulk-action, translations-toolbar-action, project-menu-action, shortcut) are triggers configured entirely in the manifest.',
           },
         },
         {
@@ -385,10 +390,10 @@ overriding `url`, `count`, and `visibility`. The icon and tooltip come from the 
 
 ### Which Tolgee App manifest modules render an iframe?
 
-`project-dashboard-page`, `translation-tools-panel`, `key-edit-tab`, and `modal` render an iframe from
-your `baseUrl`. The action modules (`key-action`, `translation-action`, `bulk-action`,
-`translations-toolbar-action`, `project-menu-action`, `shortcut`) are triggers configured entirely in
-the manifest.
+`project-dashboard-page`, `translation-tools-panel`, `translation-tools-panel-empty`, `key-edit-tab`,
+and `modal` render an iframe from your `baseUrl`. The action modules (`key-action`,
+`translation-action`, `bulk-action`, `translations-toolbar-action`, `project-menu-action`,
+`shortcut`) are triggers configured entirely in the manifest.
 
 ### How do I verify a Tolgee webhook signature?
 

--- a/tolgee-apps/api.mdx
+++ b/tolgee-apps/api.mdx
@@ -135,6 +135,7 @@ app.dispose();                            // detach the message listener
 | --- | --- | --- |
 | `context` | `Promise<TolgeeAppContext>` | Resolves when the parent posts `tolgee-app:init`. |
 | `onSelectionChanged` | `(handler: (s: TolgeeAppSelection) => void) => () => void` | Subscribe to focus changes; returns an unsubscribe fn; fires once with the initial selection. |
+| `onThemeChanged` | `(handler: (t: TolgeeAppTheme) => void) => () => void` | Subscribe to light/dark theme changes; returns an unsubscribe fn; fires once with the initial theme. |
 | `resize` | `(height: number) => void` | Request an iframe height. |
 | `close` | `() => void` | Close the containing modal/panel. |
 | `dispose` | `() => void` | Remove the listener. |
@@ -146,6 +147,7 @@ type TolgeeAppContext = {
   organizationId: number;
   projectId: number;
   selection: TolgeeAppSelection;
+  theme: TolgeeAppTheme;            // host light/dark + palette; see onThemeChanged
   extra: Record<string, unknown>;   // trigger-specific extras (e.g. selectedKeyIds for bulk actions)
 };
 
@@ -156,7 +158,34 @@ type TolgeeAppSelection = {
   translationId?: number;
   selectedLanguages?: string[];   // tags shown in the view (translation-tools-panel-empty only)
 };
+
+type TolgeeAppTheme = {
+  mode: 'light' | 'dark';
+  colors: {
+    background: string; backgroundPaper: string;
+    text: string; textSecondary: string;
+    primary: string; primaryContrast: string;
+    divider: string; error: string;
+  };
+};
 ```
+
+### `applyTolgeeTheme(theme, root?)`
+
+Applies the host theme to the iframe document so the plugin matches Tolgee: exposes each color as a
+`--tg-color-*` CSS variable (`--tg-color-background`, `--tg-color-text-secondary`, …), sets
+`[data-tg-theme="light|dark"]`, and sets `color-scheme`. Call it on init and from `onThemeChanged` to
+follow live toggles:
+
+```ts
+import { createTolgeeApp, applyTolgeeTheme } from '@tolgee/apps-sdk/browser';
+
+const app = createTolgeeApp();
+app.onThemeChanged(applyTolgeeTheme);   // fires once with the initial theme, then on every toggle
+```
+
+Then key your CSS off the variables, e.g. `background: var(--tg-color-background); color: var(--tg-color-text);`.
+Don't use `@media (prefers-color-scheme)` — Tolgee's theme can differ from the OS.
 
 ### `createTolgeeAppClient(context): TolgeeRestClient`
 
@@ -203,8 +232,9 @@ If you don't use the SDK, the iframe ↔ host messages are:
 | Direction | Message | Payload |
 | --- | --- | --- |
 | iframe → host | `tolgee-app:ready` | — (signals the iframe is listening) |
-| host → iframe | `tolgee-app:init` | `{ token, apiUrl, organizationId, projectId, selection…, extra… }` |
+| host → iframe | `tolgee-app:init` | `{ token, apiUrl, organizationId, projectId, selection…, theme, extra… }` |
 | host → iframe | `tolgee-app:selection-changed` | `{ keyId?, languageId?, languageTag?, translationId?, selectedLanguages? }` |
+| host → iframe | `tolgee-app:theme-changed` | `{ theme: { mode, colors } }` |
 | iframe → host | `tolgee-app:resize` | `{ height }` |
 | iframe → host | `tolgee-app:close` | — |
 

--- a/tolgee-apps/api.mdx
+++ b/tolgee-apps/api.mdx
@@ -5,6 +5,13 @@ sidebar_label: API reference
 description: Manifest schema, SDK, postMessage protocol, webhooks, decorators, scopes, and the CLI.
 ---
 
+import Head from '@docusaurus/Head';
+
+This reference documents the Tolgee Apps contract: the manifest schema, the `@tolgee/apps-sdk` browser
+and server APIs, the iframe `postMessage` protocol, the context token, the webhook signature scheme,
+the decorators request and response, permission scopes, the app REST endpoints, and the `tolgee-app`
+CLI. Use it alongside the [setup guide](./setup) and the tutorials when building a Tolgee App.
+
 :::warning Experimental
 Tolgee Apps is in **alpha** — the contracts on this page may change.
 :::
@@ -304,3 +311,87 @@ The `tolgee-app` binary (from `@tolgee/apps-dev`) powers local development:
 | `tolgee-app register` | One-time install via the browser consent flow. `--pat=tgpat_…` for a headless install. |
 
 Both read `.env.local` (`TOLGEE_URL`, ports) and the install record at `.tolgee-dev/install.json`.
+
+## Frequently asked questions
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'How are Tolgee App webhooks authenticated?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Each webhook carries a Tolgee-Signature header containing a timestamp and an HMAC-SHA256 signature over "timestamp.rawBody", keyed with the install’s webhookSecret. Verify it over the raw request bytes; the @tolgee/apps-sdk helpers verifyWebhookSignature and receiveWebhook do this for you.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'What does the Tolgee App context token grant?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'The context token is a short-lived JWT (audience tg.app) identifying the install, project, and user. Pass it as a Bearer token to call the Tolgee REST API. Effective permissions are the intersection of the app’s granted scopes and the user’s project permissions.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'How do dynamic decorators work in a Tolgee App?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'For action modules marked dynamic: true, Tolgee POSTs the keys and languages currently in view to your manifest decoratorsUrl. You return items referencing a manifest actionKey, optionally overriding url, count, and visibility. The icon and tooltip come from the manifest action.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Which Tolgee App manifest modules render an iframe?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'project-dashboard-page, translation-tools-panel, key-edit-tab, and modal render an iframe from your baseUrl. The action modules (key-action, translation-action, bulk-action, translations-toolbar-action, project-menu-action, shortcut) are triggers configured entirely in the manifest.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'How do I verify a Tolgee webhook signature?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Read the request body as raw text, then call verifyWebhookSignature({ header, rawBody, secret }) from @tolgee/apps-sdk/server, or use receiveWebhook to verify and parse in one step. Never parse JSON before verifying, because the signature is computed over the raw bytes.',
+          },
+        },
+      ],
+    })}
+  </script>
+</Head>
+
+### How are Tolgee App webhooks authenticated?
+
+Each webhook carries a `Tolgee-Signature` header containing a timestamp and an HMAC-SHA256 signature
+over `"timestamp.rawBody"`, keyed with the install's `webhookSecret`. Verify it over the raw request
+bytes; the SDK helpers `verifyWebhookSignature` and `receiveWebhook` do this for you.
+
+### What does the Tolgee App context token grant?
+
+The context token is a short-lived JWT (audience `tg.app`) identifying the install, project, and user.
+Pass it as a Bearer token to call the Tolgee REST API. Effective permissions are the intersection of
+the app's granted scopes and the user's project permissions.
+
+### How do dynamic decorators work in a Tolgee App?
+
+For action modules marked `dynamic: true`, Tolgee POSTs the keys and languages currently in view to
+your manifest `decoratorsUrl`. You return items referencing a manifest `actionKey`, optionally
+overriding `url`, `count`, and `visibility`. The icon and tooltip come from the manifest action.
+
+### Which Tolgee App manifest modules render an iframe?
+
+`project-dashboard-page`, `translation-tools-panel`, `key-edit-tab`, and `modal` render an iframe from
+your `baseUrl`. The action modules (`key-action`, `translation-action`, `bulk-action`,
+`translations-toolbar-action`, `project-menu-action`, `shortcut`) are triggers configured entirely in
+the manifest.
+
+### How do I verify a Tolgee webhook signature?
+
+Read the request body as raw text, then call `verifyWebhookSignature({ header, rawBody, secret })` from
+`@tolgee/apps-sdk/server`, or use `receiveWebhook` to verify and parse in one step. Never parse JSON
+before verifying, because the signature is computed over the raw bytes.

--- a/tolgee-apps/api.mdx
+++ b/tolgee-apps/api.mdx
@@ -1,0 +1,306 @@
+---
+id: api
+title: Tolgee Apps API reference
+sidebar_label: API reference
+description: Manifest schema, SDK, postMessage protocol, webhooks, decorators, scopes, and the CLI.
+---
+
+:::warning Experimental
+Tolgee Apps is in **alpha** — the contracts on this page may change.
+:::
+
+## Manifest
+
+Your app hosts a manifest JSON describing what it contributes. Tolgee fetches it at install time and
+on refresh.
+
+```json
+{
+  "id": "my-app",
+  "name": "My App",
+  "version": "0.1.0",
+  "baseUrl": "https://my-app.example.com",
+  "decoratorsUrl": "https://my-app.example.com/decorators",
+  "scopes": ["translations.view", "keys.view"],
+  "webhooks": {
+    "events": ["SET_TRANSLATIONS", "CREATE_KEY"],
+    "url": "/webhook"
+  },
+  "modules": {
+    "project-dashboard-page": [
+      { "key": "home", "title": "My App", "icon": "LayoutAlt04", "entry": "/dashboard" }
+    ]
+  }
+}
+```
+
+### Top-level fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Stable, unique identifier. Cannot change after install. |
+| `name` | string | Display name. |
+| `version` | string | semver recommended. |
+| `baseUrl` | string | Where module `entry` paths and a relative `webhooks.url` resolve. HTTPS in production. |
+| `decoratorsUrl` | string? | Absolute URL of your decorators endpoint (see [Decorators](#decorators)). |
+| `scopes` | string[]? | Permission scopes requested at install (see [Scopes](#scopes--permissions)). |
+| `webhooks` | object? | `{ events: string[], url: string }` — event names + delivery URL (relative to `baseUrl` or absolute). |
+| `modules` | object? | The UI contributions, keyed by module type. |
+
+### Modules
+
+Iframe modules render a page from your `baseUrl`:
+
+```ts
+type AppIframeModule = {
+  key: string;        // unique within the plugin
+  title: string;
+  icon?: string;      // emoji or a platform icon name (e.g. "LayoutAlt04")
+  entry: string;      // path under baseUrl
+  width?: number;     // modal only
+  height?: number;    // modal only
+};
+```
+
+Used by: `project-dashboard-page`, `translation-tools-panel`, `key-edit-tab`, `modal`.
+
+Action modules are triggers; they don't render their own page but point at an iframe module or a link:
+
+```ts
+type AppAction = {
+  key: string;
+  type: 'link' | 'tab' | 'panel' | 'modal';
+  icon?: string;
+  tooltip?: string;
+  title?: string;
+  urlTemplate?: string;  // link: target URL, may contain placeholders (below)
+  tabKey?: string;       // tab: a key-edit-tab key
+  panelKey?: string;     // panel: a translation-tools-panel key
+  modalKey?: string;     // modal: a modal key
+  dynamic?: boolean;     // visibility/badge driven by decoratorsUrl
+};
+
+type AppShortcut = Omit<AppAction, 'type'> & {
+  combination: string;             // e.g. "Mod+Shift+E" (Mod = ⌘ / Ctrl)
+  type: 'link' | 'modal';
+};
+```
+
+Allowed action `type` per module (enforced at install time):
+
+| Module | Allowed types | Required ref |
+| --- | --- | --- |
+| `key-action` | `link`, `tab`, `modal` | `tabKey` / `modalKey` (or `urlTemplate` for link) |
+| `translation-action` | `link`, `panel`, `modal` | `panelKey` / `modalKey` (or `urlTemplate`) |
+| `bulk-action` | `link`, `modal` | `modalKey` (or `urlTemplate`) |
+| `translations-toolbar-action` | `link`, `modal` | `modalKey` (or `urlTemplate`) |
+| `project-menu-action` | `link`, `modal` | `modalKey` (or `urlTemplate`) |
+| `shortcut` | `link`, `modal` | `combination` + `modalKey` (or `urlTemplate`) |
+
+A `link` action requires `urlTemplate` **unless** it is `dynamic` (then the URL comes from the
+decorators response). `urlTemplate` may contain `{keyId}`, `{keyName}`, `{keyNamespace}`,
+`{projectId}`, `{languageTag}`, `{languageId}`, `{translationId}`.
+
+## SDK — browser (`@tolgee/apps-sdk/browser`)
+
+For iframe modules.
+
+### `createTolgeeApp(): TolgeeApp`
+
+Sets up the `postMessage` handshake with Tolgee.
+
+```ts
+import { createTolgeeApp } from '@tolgee/apps-sdk/browser';
+
+const app = createTolgeeApp();
+const ctx = await app.context;            // resolves once Tolgee sends init
+const off = app.onSelectionChanged((s) => { /* s: TolgeeAppSelection */ });
+app.resize(420);                          // ask the host to resize the iframe
+app.close();                              // close the containing modal/panel
+app.dispose();                            // detach the message listener
+```
+
+| Member | Signature | Description |
+| --- | --- | --- |
+| `context` | `Promise<TolgeeAppContext>` | Resolves when the parent posts `tolgee-app:init`. |
+| `onSelectionChanged` | `(handler: (s: TolgeeAppSelection) => void) => () => void` | Subscribe to focus changes; returns an unsubscribe fn; fires once with the initial selection. |
+| `resize` | `(height: number) => void` | Request an iframe height. |
+| `close` | `() => void` | Close the containing modal/panel. |
+| `dispose` | `() => void` | Remove the listener. |
+
+```ts
+type TolgeeAppContext = {
+  token: string;            // context JWT — use as a Bearer token to call Tolgee
+  apiUrl: string;
+  organizationId: number;
+  projectId: number;
+  selection: TolgeeAppSelection;
+  extra: Record<string, unknown>;   // trigger-specific extras (e.g. selectedKeyIds for bulk actions)
+};
+
+type TolgeeAppSelection = {
+  keyId?: number;
+  languageId?: number;
+  languageTag?: string;
+  translationId?: number;
+};
+```
+
+### `createTolgeeAppClient(context): TolgeeRestClient`
+
+A typed Tolgee REST client wired with the context token, base URL, and project id. Errors are
+returned in the `error` field (no throwing).
+
+```ts
+import { createTolgeeAppClient } from '@tolgee/apps-sdk/browser';
+
+const tolgee = createTolgeeAppClient(ctx);
+const { data, error } = await tolgee.GET('/v2/projects/{projectId}/translations', {
+  params: { path: { projectId: ctx.projectId }, query: { size: 20 } },
+});
+```
+
+## SDK — server (`@tolgee/apps-sdk/server`)
+
+Framework-agnostic helpers for your backend (no Express dependency).
+
+| Export | Signature | Description |
+| --- | --- | --- |
+| `receiveWebhook` | `(input: { rawBody: string; signatureHeader: string \| null \| undefined; secret: string \| null \| undefined }) => Promise<{ ok: true; payload } \| { ok: false; status: 401 \| 400; error: string }>` | Verifies the signature over the **raw** body and parses the typed payload. |
+| `onWebhook` | `(payload, types: T \| readonly T[], handler: (typed) => void) => boolean` | Type-narrowing dispatcher by activity type; returns true if the handler ran. |
+| `verifyWebhookSignature` | `({ header, rawBody, secret }) => Promise<boolean>` | HMAC-SHA256 verification (WebCrypto, timing-safe). |
+| `decodeContextToken` | `(jwt: string) => AppContextClaims` | Decodes (does **not** verify) the context token into `{ installId, projectId, userId, audience, expiresAt }`. |
+| `tolgeeAppCorsHeaders` | `() => Record<string, string>` | CORS headers your decorator/API endpoints must return (wildcard origin + `Authorization`). |
+| `renderManifest` | `(template: string, baseUrl: string) => string` | Replaces `__BASE_URL__` in a manifest template with the live URL. |
+| `loadTolgeeAppConfig` | `(env?) => { tolgeeUrl, webhookSecret, vitePort, serverPort }` | Reads the standard env vars (`TOLGEE_URL`, `TOLGEE_WEBHOOK_SECRET`, `VITE_PORT`, `SERVER_PORT`). |
+
+```ts
+import { receiveWebhook, onWebhook } from '@tolgee/apps-sdk/server';
+
+const r = await receiveWebhook({ rawBody, signatureHeader, secret });
+if (!r.ok) return res.status(r.status).json({ error: r.error });
+onWebhook(r.payload, 'SET_TRANSLATIONS', (typed) => {
+  // typed is narrowed to the SET_TRANSLATIONS payload
+});
+```
+
+## postMessage protocol
+
+If you don't use the SDK, the iframe ↔ host messages are:
+
+| Direction | Message | Payload |
+| --- | --- | --- |
+| iframe → host | `tolgee-app:ready` | — (signals the iframe is listening) |
+| host → iframe | `tolgee-app:init` | `{ token, apiUrl, organizationId, projectId, selection…, extra… }` |
+| host → iframe | `tolgee-app:selection-changed` | `{ keyId?, languageId?, languageTag?, translationId? }` |
+| iframe → host | `tolgee-app:resize` | `{ height }` |
+| iframe → host | `tolgee-app:close` | — |
+
+## Context token
+
+The init message carries a short-lived JWT:
+
+- **Audience** `tg.app`; claims `sub` (userId), `tg.app.inst` (installId), `tg.app.proj` (projectId),
+  plus `iat`/`exp`.
+- Pass it as `Authorization: Bearer <token>` on REST calls; Tolgee verifies the signature server-side.
+- It is **not** a substitute for verifying user identity yourself — your backend should treat it as
+  an opaque bearer credential and let Tolgee enforce permissions.
+
+## Webhooks
+
+Tolgee POSTs subscribed events to `webhooks.url`. The request carries a signature header:
+
+```
+Tolgee-Signature: {"timestamp": 1717000000000, "signature": "<hex>"}
+```
+
+The signature is `HMAC-SHA256(secret, "<timestamp>.<raw-request-body>")`, where `secret` is the
+install's `webhookSecret`. **Verify over the raw bytes** — read the body as text before any JSON
+parsing. The SDK's `receiveWebhook` / `verifyWebhookSignature` do this for you.
+
+Batch events (e.g. `BATCH_KEY_DELETE`) carry a `revisionId`; fetch the full set of changes from the
+activity API. See the platform [webhooks docs](/platform/projects_and_organizations/webhooks) for the
+event list and payload shapes.
+
+## Decorators
+
+For dynamic action modules (`dynamic: true`), Tolgee asks your app which keys/cells to decorate. It
+POSTs to `manifest.decoratorsUrl` with a user context token as `Authorization: Bearer`:
+
+**Request**
+
+```ts
+{
+  installId: number,
+  projectId: number,
+  keyIds?: number[],       // key rows currently in view
+  languageTags?: string[]  // language columns in view
+}
+```
+
+**Response**
+
+```ts
+{
+  items?: Array<{
+    keyId: number,
+    languageTag?: string | null,   // omit for a key-row decoration; set for a translation cell
+    actionKey: string,             // must match a declared key-action / translation-action key
+    url?: string,                  // for link actions: overrides the manifest urlTemplate
+    count?: number,                // badge count
+    visibility?: 'always' | 'on-hover'
+  }>
+}
+```
+
+The decoration's `icon` and `tooltip` come from the matching **manifest action**; the response only
+references it by `actionKey` and may override `url`, `count`, and `visibility`. Your endpoint must
+return the CORS headers from `tolgeeAppCorsHeaders()` (see the server SDK above) and allow the
+`Authorization` header.
+
+## Scopes & permissions
+
+Apps request scopes in the manifest; the wizard offers this common set:
+
+```
+translations.view, translations.edit, translations.state-edit, translations.suggest,
+keys.view, keys.create, keys.edit, keys.delete,
+screenshots.view, screenshots.upload,
+activity.view
+```
+
+At runtime, an app's effective permissions on a project are the **intersection** of the scopes
+granted to the install and the calling **user's** own project permissions (scopes are expanded by
+hierarchy first — e.g. `keys.edit` implies `keys.view`). An app can never exceed what the user can do.
+
+Because there is no incremental consent yet, request every scope you need at install time. The
+plugin-authenticated self-service endpoint can only **narrow** scopes, never widen them.
+
+## REST endpoints
+
+Apps reuse the standard Tolgee [REST API](/api). The app-management endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /v2/organizations/{orgId}/apps/preview` | Validate a manifest without installing |
+| `POST /v2/organizations/{orgId}/apps` | Install (owner only) — returns clientId/secret + webhookSecret |
+| `GET /v2/organizations/{orgId}/apps` | List installs |
+| `POST /v2/organizations/{orgId}/apps/{installId}/refresh` | Re-fetch the manifest |
+| `PATCH /v2/organizations/{orgId}/apps/{installId}/manifest-url` | Repoint at a new manifest URL |
+| `DELETE /v2/organizations/{orgId}/apps/{installId}` | Uninstall |
+| `PATCH /v2/apps/self/manifest-url` | App repoints its own manifest URL (auth: `X-API-Key: tgapps_<clientSecret>`) |
+| `GET /v2/projects/{projectId}/apps` | List installs + per-project enablement |
+| `PUT /v2/projects/{projectId}/apps/{installId}` | Enable for a project |
+| `DELETE /v2/projects/{projectId}/apps/{installId}` | Disable for a project |
+| `POST /v2/projects/{projectId}/apps/{installId}/token` | Mint a user context token |
+
+## CLI
+
+The `tolgee-app` binary (from `@tolgee/apps-dev`) powers local development:
+
+| Command | What it does |
+| --- | --- |
+| `tolgee-app dev` | Boots a Cloudflare quick tunnel to your local app and repoints the install's manifest URL on every restart (skips the tunnel when Tolgee is local). |
+| `tolgee-app register` | One-time install via the browser consent flow. `--pat=tgpat_…` for a headless install. |
+
+Both read `.env.local` (`TOLGEE_URL`, ports) and the install record at `.tolgee-dev/install.json`.

--- a/tolgee-apps/intro.mdx
+++ b/tolgee-apps/intro.mdx
@@ -5,6 +5,14 @@ sidebar_label: Introduction
 description: Build apps that extend the Tolgee UI, react to project events, and decorate translation rows.
 ---
 
+import Head from '@docusaurus/Head';
+
+Tolgee Apps are hosted web plugins that extend Tolgee with custom UI — dashboard pages, side panels,
+key-edit tabs, modals, and row action icons — while reacting to project events through signed
+webhooks and decorating translation rows with live data. A Tolgee App calls the Tolgee REST API
+scoped to the permissions granted at install time. You build one with the `create-tolgee-app`
+scaffolder and the `@tolgee/apps-sdk`.
+
 :::warning Experimental
 Tolgee Apps is in **alpha**. The packages are published under the npm `alpha` dist-tag and the
 APIs described here may change without notice. Don't build production-critical workflows on it yet.
@@ -119,3 +127,86 @@ granted scopes and the user's project permissions (see [Scopes & permissions](./
   [Setup](./setup#local-development)).
 
 These are alpha constraints and will change as the platform matures.
+
+## Frequently asked questions
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What can a Tolgee App do?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'A Tolgee App can add UI to the Tolgee interface (dashboard pages, panels, key-edit tabs, modals, row action icons, and keyboard shortcuts), subscribe to project events through signed webhooks, decorate translation rows with live badges, and call the Tolgee REST API scoped to the permissions granted at install.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'How is a Tolgee App different from a Tolgee integration like Figma or Slack?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Tolgee integrations are first-party connectors maintained by Tolgee. Tolgee Apps are a developer platform: you build and host your own app, describe it with a manifest, and install it into your organization. Apps run in a sandboxed iframe and react to webhooks.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Do Tolgee Apps work on self-hosted Tolgee?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Yes. A Tolgee App targets any Tolgee instance that has Apps enabled, including self-hosted ones. You point the install at your instance URL. For local development against a localhost instance, you must enable an SSRF bypass so Tolgee can fetch your manifest.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'What permissions does a Tolgee App get?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'A Tolgee App requests permission scopes in its manifest, approved by an organization owner at install. At runtime the effective permissions are the intersection of the app’s granted scopes and the calling user’s own project permissions, so an app can never do more than the user.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Is Tolgee Apps production-ready?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Not yet. Tolgee Apps is in alpha and its packages are published under the npm alpha dist-tag. The contracts may change, so avoid production-critical workflows for now.',
+          },
+        },
+      ],
+    })}
+  </script>
+</Head>
+
+### What can a Tolgee App do?
+
+A Tolgee App can add UI to the Tolgee interface (dashboard pages, panels, key-edit tabs, modals, row
+action icons, and keyboard shortcuts), subscribe to project events through signed webhooks, decorate
+translation rows with live badges, and call the Tolgee REST API scoped to the permissions granted at
+install.
+
+### How is a Tolgee App different from a Tolgee integration like Figma or Slack?
+
+Tolgee integrations are first-party connectors maintained by Tolgee. Tolgee Apps are a developer
+platform: you build and host your own app, describe it with a manifest, and install it into your
+organization. Apps run in a sandboxed iframe and react to webhooks.
+
+### Do Tolgee Apps work on self-hosted Tolgee?
+
+Yes. A Tolgee App targets any Tolgee instance that has Apps enabled, including self-hosted ones. You
+point the install at your instance URL. For local development against a localhost instance, you must
+enable an SSRF bypass so Tolgee can fetch your manifest (see [Setup](./setup#local-development)).
+
+### What permissions does a Tolgee App get?
+
+A Tolgee App requests permission scopes in its manifest, approved by an organization owner at install.
+At runtime the effective permissions are the intersection of the app's granted scopes and the calling
+user's own project permissions, so an app can never do more than the user.
+
+### Is Tolgee Apps production-ready?
+
+Not yet. Tolgee Apps is in alpha and its packages are published under the npm `alpha` dist-tag. The
+contracts may change, so avoid production-critical workflows for now.

--- a/tolgee-apps/intro.mdx
+++ b/tolgee-apps/intro.mdx
@@ -1,0 +1,121 @@
+---
+id: intro
+title: Tolgee Apps — introduction & architecture
+sidebar_label: Introduction
+description: Build apps that extend the Tolgee UI, react to project events, and decorate translation rows.
+---
+
+:::warning Experimental
+Tolgee Apps is in **alpha**. The packages are published under the npm `alpha` dist-tag and the
+APIs described here may change without notice. Don't build production-critical workflows on it yet.
+:::
+
+## Overview
+
+**Tolgee Apps** let you extend Tolgee with your own hosted web app. An app can:
+
+- **Add UI** to the Tolgee interface — full dashboard pages, side panels, key-edit tabs, modals,
+  icon buttons on key/translation rows, and keyboard shortcuts.
+- **React to project events** — receive signed **webhooks** when translations change, keys are
+  created, imports finish, and more.
+- **Decorate rows dynamically** — push badges/icons onto specific keys and translation cells based
+  on your own data.
+- **Call the Tolgee REST API** on behalf of the current user, scoped to the permissions the app was
+  granted at install time.
+
+An app is just a web service you host. Tolgee loads its UI in a sandboxed `<iframe>` and talks to it
+over `postMessage`; your backend receives webhooks and serves decorator data. You describe everything
+in a **manifest** (a JSON file your app hosts).
+
+To go from zero to a running app, use the scaffolder and SDK:
+
+- **`create-tolgee-app`** — scaffolds a working app (Vite + React frontend, Express backend, dev
+  tunnel, manifest) in one command.
+- **`@tolgee/apps-sdk`** — the postMessage handshake, a typed REST client, webhook signature
+  verification, and the manifest types.
+- **`@tolgee/apps-dev`** (the `tolgee-app` CLI) — the dev tunnel and one-time browser install.
+
+See [Setup & quickstart](./setup) to build your first app, the [API reference](./api) for the full
+contract, and the [tutorials](./tutorial-activity-monitoring) for end-to-end examples.
+
+## How it fits together
+
+```
+   your app (hosted)                         Tolgee
+   ─────────────────                         ──────
+   manifest.json  ───────── install ───────▶ Organization install + consent (scopes)
+                                                      │
+                                              enable per project
+                                                      │
+   iframe module  ◀──── load + context token ─────────┤   postMessage handshake
+        │                                              │   (init / selection / resize / close)
+        └──── REST call (Bearer token) ──────────────▶ REST API   (scopes = app ∩ user)
+                                                      │
+   /webhook       ◀──── signed webhook ───────────────┤   on translation/key/import events
+   /decorators    ◀──── POST (keyIds, langs) ─────────┘   render badges on rows
+```
+
+1. **Install & consent** — an organization **owner** installs your app by pointing Tolgee at your
+   manifest URL. Tolgee shows the requested **scopes** and the owner approves. Installation returns
+   a `clientId`, `clientSecret`, and a per-install `webhookSecret`.
+2. **Enable per project** — a project member enables the installed app on a specific project. Only
+   then do its modules appear and its webhooks fire for that project.
+3. **Modules in an iframe** — when a user opens one of your modules, Tolgee renders your `entry` URL
+   in a sandboxed iframe and completes a `postMessage` handshake, delivering a **context token** (a
+   short-lived JWT with `aud=tg.app` carrying the install, project, and user ids) plus the current
+   selection (focused key/language/translation).
+4. **REST API access** — your iframe uses the context token as a Bearer token to call the Tolgee
+   REST API. The app's effective permissions are the **intersection** of the scopes granted to the
+   install and the calling user's own project permissions — an app can never do more than the user.
+5. **Webhooks** — Tolgee POSTs subscribed events to your `webhooks.url`, signed with the install's
+   `webhookSecret` (a `Tolgee-Signature` header). Your backend verifies the signature and reacts.
+6. **Decorators** — for dynamic row badges, Tolgee POSTs the keys/languages currently in view to your
+   `decoratorsUrl`; you return the items to render.
+
+## Capabilities
+
+### UI modules
+
+A manifest declares modules under these keys. The first four render an iframe (your web page); the
+rest are lightweight triggers configured entirely in the manifest.
+
+| Module | Renders | Use it for |
+| --- | --- | --- |
+| `project-dashboard-page` | iframe | A full-area page in the project sidebar |
+| `translation-tools-panel` | iframe | A collapsible panel in the translations view; receives selection updates |
+| `key-edit-tab` | iframe | A tab inside the key-edit dialog |
+| `modal` | iframe | A dialog opened from any action |
+| `key-action` | icon button on a key row | Opens a `key-edit-tab` or an external `link` |
+| `translation-action` | icon button on a translation cell | Opens a `translation-tools-panel` or a `link` |
+| `bulk-action` | item in the bulk-action bar | Opens a `modal` or a `link` for selected keys |
+| `translations-toolbar-action` | button in the translations toolbar | Opens a `modal` or a `link` |
+| `project-menu-action` | entry in the project sidebar | Opens a `modal` or a `link` |
+| `shortcut` | keyboard shortcut | Triggers a `modal` or a `link` |
+
+Action modules can be **dynamic** (`dynamic: true`): their visibility/badge is driven by your
+`decoratorsUrl` response rather than shown statically on every row.
+
+### Events (webhooks)
+
+Subscribe to Tolgee [activity types](/platform/projects_and_organizations/webhooks) such as
+`SET_TRANSLATIONS`, `SET_TRANSLATION_STATE`, `CREATE_KEY`, `KEY_DELETE`, `IMPORT`, and their batch
+variants. Deliveries are HMAC-signed; the SDK verifies them for you.
+
+### REST API
+
+Call any Tolgee REST endpoint with the context token. Permissions are the intersection of the app's
+granted scopes and the user's project permissions (see [Scopes & permissions](./api#scopes--permissions)).
+
+## Limitations (alpha)
+
+- **Hosted only.** Your app must be reachable at an HTTPS URL; there is no zip/bundle upload yet.
+- **No incremental consent.** An app's scopes are approved once at install time — request everything
+  you need up front. Adding scopes later requires an owner to re-approve.
+- **Webhook secret at rest.** Per-install `webhookSecret` is currently stored unencrypted.
+- **Shared signing key.** Context tokens are signed with the platform's JWT key (distinguished by
+  `aud=tg.app`); a dedicated key/JWKS is planned.
+- **Local development needs an SSRF bypass.** Tolgee refuses to fetch manifests from private/loopback
+  addresses; when developing against a local Tolgee, enable the documented bypass (see
+  [Setup](./setup#local-development)).
+
+These are alpha constraints and will change as the platform matures.

--- a/tolgee-apps/setup.mdx
+++ b/tolgee-apps/setup.mdx
@@ -1,0 +1,148 @@
+---
+id: setup
+title: Setup & quickstart
+sidebar_label: Setup & quickstart
+description: Scaffold, run, and install your first Tolgee App with create-tolgee-app and the SDK.
+---
+
+:::warning Experimental
+Tolgee Apps is in **alpha** — packages are published under the npm `alpha` dist-tag and APIs may change.
+:::
+
+This guide takes you from nothing to a running app installed on a project.
+
+## Prerequisites
+
+- **Node.js ≥ 20**
+- A **Tolgee instance** with Apps enabled, and the URL where you open its UI (e.g.
+  `https://app.tolgee.io`, or `http://localhost:3000` for local development).
+- An organization where you have the **owner** role (installing an app is owner-only).
+
+## 1. Scaffold an app
+
+```bash
+npm create tolgee-app@alpha my-app
+```
+
+The wizard asks, in order:
+
+1. **App identifier** — kebab-case; becomes the folder name and the manifest `id`.
+2. **Display name** — shown in the Tolgee admin UI.
+3. **Modules** — which UI surfaces to contribute (multiselect).
+4. **Permission scopes** — what the app may do via the REST API (multiselect).
+5. **Webhook events** — which project events to subscribe to (multiselect; optional).
+6. **Tolgee URL** — the instance to target.
+7. **Dev ports** — a free Vite/server port pair (auto-detected; editable).
+8. **Install dependencies now?**
+9. **Initialize a git repo?**
+
+### Non-interactive (CI / scripted)
+
+Pass `--yes` (or `-y`) and provide answers as flags:
+
+```bash
+npm create tolgee-app@alpha my-app -- --yes \
+  --modules=project-dashboard-page,translation-tools-panel \
+  --scopes=translations.view,keys.view \
+  --webhooks=SET_TRANSLATIONS,CREATE_KEY \
+  --tolgee-url=http://localhost:3000
+```
+
+Other flags: `--vite-port` / `--server-port` (auto-picked if omitted), `--install`, `--git`.
+
+## 2. What you get
+
+```
+my-app/
+  manifest.template.json   # your manifest; __BASE_URL__ is substituted at request time
+  src/                     # iframe modules (one entry per UI module)
+  server/                  # Express: /manifest.json, /webhook, /decorators routes
+  .env.local               # TOLGEE_URL + dev ports (generated, gitignored)
+  package.json             # dev / register / build scripts
+```
+
+Notable scripts:
+
+| Script | What it does |
+| --- | --- |
+| `npm run dev` | Runs Vite + the Express server + the dev tunnel together |
+| `npm run register` | One-time browser install against your Tolgee instance |
+| `npm run build` | Production build (`tsc` + `vite build`) |
+
+`npm run dev` and `npm run register` delegate to the `tolgee-app` CLI (from
+[`@tolgee/apps-dev`](./api#cli)).
+
+## 3. Run it
+
+Open **two terminals** in the project. Start `dev` **first** — `register` checks that your app's
+manifest is reachable, so the server has to be up.
+
+```bash
+# terminal 1 — Vite + Express + tunnel
+npm run dev
+```
+
+`dev` boots a **Cloudflare quick tunnel** so a remote Tolgee can reach your local app, and repoints
+the install at the fresh tunnel URL on every restart. When `TOLGEE_URL` is `localhost`, it skips the
+tunnel — Tolgee reaches your app directly.
+
+```bash
+# terminal 2 — one-time install
+npm run register
+```
+
+`register` opens your Tolgee instance's install page in the browser. Review the requested scopes,
+pick an organization, and approve. Credentials (including the `webhookSecret`) are written to
+`.tolgee-dev/install.json`; the dev server reads the webhook secret from there — you don't copy it
+anywhere.
+
+:::tip Headless install
+For CI or headless machines, skip the browser: `npm run register -- --pat=tgpat_…` with a
+[Personal Access Token](/platform/account_settings/api_keys_and_pat_tokens).
+:::
+
+## 4. Enable it on a project
+
+Installing makes the app available to the organization; you still enable it per project:
+
+1. Open a project in Tolgee.
+2. Enable **my-app** in the project's apps settings.
+3. Open the module you scaffolded (e.g. the dashboard page or the translations panel) — your iframe
+   loads and completes the context handshake.
+
+Edit `src/` to change the UI (Vite hot-reloads) and `manifest.template.json` to change what your app
+contributes (restart `npm run dev` so Tolgee re-fetches the manifest).
+
+## 5. Building without the scaffolder
+
+If you'd rather wire an existing project, install the SDK directly:
+
+```bash
+npm i @tolgee/apps-sdk@alpha
+npm i -D @tolgee/apps-dev@alpha   # the tolgee-app dev/register CLI
+```
+
+`@tolgee/apps-sdk/browser` powers iframe modules and `@tolgee/apps-sdk/server` powers your webhook /
+decorator endpoints — see the [API reference](./api).
+
+## Local development
+
+`create-tolgee-app` defaults `TOLGEE_URL` to your chosen instance. To develop against a **local**
+Tolgee, Tolgee must fetch your manifest from `localhost`, which its SSRF protection blocks by
+default. Enable the bypass in your local Tolgee config (`application-dev.yaml`):
+
+```yaml
+tolgee:
+  internal:
+    disable-url-ssrf-protection: true
+```
+
+:::warning
+This bypass is for local development only. Never enable it on a publicly reachable instance.
+:::
+
+## Next steps
+
+- [API reference](./api) — manifest schema, SDK, webhooks, decorators, scopes.
+- [Tutorial: activity monitoring](./tutorial-activity-monitoring) — webhooks + a panel + decorators.
+- [Tutorial: back-translation](./tutorial-back-translation) — an LLM-powered QA app.

--- a/tolgee-apps/setup.mdx
+++ b/tolgee-apps/setup.mdx
@@ -5,11 +5,16 @@ sidebar_label: Setup & quickstart
 description: Scaffold, run, and install your first Tolgee App with create-tolgee-app and the SDK.
 ---
 
+import Head from '@docusaurus/Head';
+
+This guide builds and installs your first Tolgee App. You scaffold a project with `create-tolgee-app`,
+run it locally behind a dev tunnel, install it on your Tolgee organization through a browser consent
+flow, then enable it on a project. In a few minutes you have a working Tolgee App contributing UI and
+receiving webhooks. Tolgee Apps is alpha, so expect rough edges.
+
 :::warning Experimental
 Tolgee Apps is in **alpha** — packages are published under the npm `alpha` dist-tag and APIs may change.
 :::
-
-This guide takes you from nothing to a running app installed on a project.
 
 ## Prerequisites
 
@@ -146,3 +151,84 @@ This bypass is for local development only. Never enable it on a publicly reachab
 - [API reference](./api) — manifest schema, SDK, webhooks, decorators, scopes.
 - [Tutorial: activity monitoring](./tutorial-activity-monitoring) — webhooks + a panel + decorators.
 - [Tutorial: back-translation](./tutorial-back-translation) — an LLM-powered QA app.
+
+## Frequently asked questions
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'How do I create a Tolgee App?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Run `npm create tolgee-app@alpha my-app`. The wizard asks for an identifier, display name, UI modules, permission scopes, webhook events, your Tolgee URL, and dev ports, then scaffolds a runnable project with a Vite frontend, an Express backend, and a manifest.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Why does npm run register fail with "manifest not reachable"?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'register checks that your app’s manifest is reachable, which requires the dev server to be running. Start npm run dev first (in one terminal), then run npm run register in a second terminal.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Can I develop a Tolgee App against a local Tolgee instance?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Yes. Set the Tolgee URL to your localhost instance. Because Tolgee must fetch your manifest from localhost, enable tolgee.internal.disable-url-ssrf-protection: true in the local application-dev.yaml. Never enable that bypass on a publicly reachable instance.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Where does the webhook secret come from?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Installing the Tolgee App returns a per-install webhook secret, written to .tolgee-dev/install.json by the register step. The generated dev server reads it from there, so you do not copy it anywhere. In production, set TOLGEE_WEBHOOK_SECRET in the app environment.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Can I scaffold a Tolgee App non-interactively?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Yes. Pass --yes plus flags: --modules, --scopes, --webhooks, --tolgee-url, --vite-port, --server-port, --install, --git. This is useful for CI or scripted setups.',
+          },
+        },
+      ],
+    })}
+  </script>
+</Head>
+
+### How do I create a Tolgee App?
+
+Run `npm create tolgee-app@alpha my-app`. The wizard asks for an identifier, display name, UI modules,
+permission scopes, webhook events, your Tolgee URL, and dev ports, then scaffolds a runnable project
+with a Vite frontend, an Express backend, and a manifest.
+
+### Why does `npm run register` fail with "manifest not reachable"?
+
+`register` checks that your Tolgee App's manifest is reachable, which requires the dev server to be
+running. Start `npm run dev` first (in one terminal), then run `npm run register` in a second terminal.
+
+### Can I develop a Tolgee App against a local Tolgee instance?
+
+Yes. Set the Tolgee URL to your localhost instance. Because Tolgee must fetch your manifest from
+localhost, enable `tolgee.internal.disable-url-ssrf-protection: true` in the local `application-dev.yaml`.
+Never enable that bypass on a publicly reachable instance.
+
+### Where does the webhook secret come from?
+
+Installing the Tolgee App returns a per-install webhook secret, written to `.tolgee-dev/install.json`
+by the `register` step. The generated dev server reads it from there, so you don't copy it anywhere.
+In production, set `TOLGEE_WEBHOOK_SECRET` in the app environment.
+
+### Can I scaffold a Tolgee App non-interactively?
+
+Yes. Pass `--yes` plus flags: `--modules`, `--scopes`, `--webhooks`, `--tolgee-url`, `--vite-port`,
+`--server-port`, `--install`, `--git`. This is useful for CI or scripted setups.

--- a/tolgee-apps/setup.mdx
+++ b/tolgee-apps/setup.mdx
@@ -16,6 +16,47 @@ receiving webhooks. Tolgee Apps is alpha, so expect rough edges.
 Tolgee Apps is in **alpha** — packages are published under the npm `alpha` dist-tag and APIs may change.
 :::
 
+## Build it with Claude
+
+The fastest way to start is to let an AI coding agent scaffold and build the app together with you.
+In an empty folder, open an agent that can use your terminal (such as Claude Code) and paste this
+prompt:
+
+{/* TODO: when the Apps docs are published, replace the preview URL below with https://docs.tolgee.io/apps/intro */}
+
+```text
+You are helping me create a new Tolgee App (a plugin for the Tolgee localization platform).
+
+1. First, read the Tolgee Apps docs:
+   https://deploy-preview-1116--tolgee-docs.netlify.app/apps/intro
+   and the linked Setup, API reference, and tutorial pages.
+
+2. Then ask me these questions and wait for my answers:
+   - What should the app do? (one or two sentences)
+   - Which parts of the Tolgee UI should it add? (dashboard page, translations panel,
+     key-edit tab, modal, row action icons, keyboard shortcut)
+   - Which project events should it react to, if any? (e.g. translation changed, key created)
+   - Which permission scopes does it need? (e.g. read translations, edit keys)
+   - What should the app be called? (kebab-case)
+
+3. Scaffold the project with `npm create tolgee-app@alpha <app-name>` using my answers.
+   Keep the scaffolder's DEFAULT Tolgee URL — do not change it unless I explicitly ask
+   for a different instance.
+
+4. From the new project, run `npm run pull-context` to download the SDK source, the
+   example apps, and the docs into `.context/`. Use those as the source of truth while building.
+
+5. Build the app following the docs and the example apps, using the typed SDK. Run
+   `npm run typecheck` after every change and do not stop until it passes.
+
+6. Do NOT run the dev server or the install yourself. Instead, tell me to run them:
+   `npm run dev` in one terminal, then `npm run register` in a second terminal (first run
+   only) to approve the install in my browser. Start `dev` before `register`.
+```
+
+The prompt runs `npm` commands, so use it with a terminal-capable agent. Everything it does is also
+covered step by step below, if you'd rather scaffold manually.
+
 ## Prerequisites
 
 - **Node.js ≥ 20**

--- a/tolgee-apps/tutorial-activity-monitoring.mdx
+++ b/tolgee-apps/tutorial-activity-monitoring.mdx
@@ -5,6 +5,11 @@ sidebar_label: "Tutorial: Activity monitoring"
 description: Build a Tolgee App that records translation edits via webhooks and shows per-cell activity.
 ---
 
+This tutorial builds a Tolgee App that monitors translation activity. The app subscribes to
+translation-edit webhooks, stores per-cell edit timestamps, decorates translation cells with a
+recent-edit count badge, and renders an activity sparkline in a panel when a cell is focused. You
+scaffold it with `create-tolgee-app` and verify it against a live project. Tolgee Apps is alpha.
+
 :::warning Experimental
 Tolgee Apps is in **alpha** — APIs may change.
 :::

--- a/tolgee-apps/tutorial-activity-monitoring.mdx
+++ b/tolgee-apps/tutorial-activity-monitoring.mdx
@@ -1,0 +1,214 @@
+---
+id: tutorial-activity-monitoring
+title: "Tutorial: Activity monitoring app"
+sidebar_label: "Tutorial: Activity monitoring"
+description: Build a Tolgee App that records translation edits via webhooks and shows per-cell activity.
+---
+
+:::warning Experimental
+Tolgee Apps is in **alpha** — APIs may change.
+:::
+
+In this tutorial you'll build an app that:
+
+- **records** every translation edit it hears about via a webhook,
+- **decorates** translation cells with a recent-edit **count badge**, and
+- shows a small **activity sparkline** in a panel when a cell is focused.
+
+It's a trimmed-down version of the [`dev-plugin`](https://github.com/tolgee/tolgee-platform) example —
+link to the full source at the end.
+
+## 1. Scaffold
+
+```bash
+npm create tolgee-app@alpha activity-monitor -- --yes \
+  --modules=translation-tools-panel,translation-action \
+  --scopes=translations.view,keys.view \
+  --webhooks=SET_TRANSLATIONS \
+  --tolgee-url=http://localhost:3000
+cd activity-monitor && npm install
+```
+
+This gives you a `translation-tools-panel` (the iframe panel) and a `translation-action` (the row
+icon), and subscribes to the `SET_TRANSLATIONS` event.
+
+## 2. Record edits (webhook → store)
+
+First a tiny in-memory store keyed by translation id (the real example persists to disk and prunes
+old events):
+
+```ts
+// server/activityStore.ts
+const events = new Map<number, string[]>();
+
+export const store = {
+  record(translationId: number, isoTime: string) {
+    const log = events.get(translationId) ?? [];
+    log.push(isoTime);
+    events.set(translationId, log);
+  },
+  forIds(ids: number[]): Record<number, string[]> {
+    const out: Record<number, string[]> = {};
+    for (const id of ids) out[id] = events.get(id) ?? [];
+    return out;
+  },
+};
+```
+
+The scaffold already generated `server/routes/webhook.ts` with signature verification via
+`receiveWebhook`. Fill in the handler to record the modified translations:
+
+```ts
+// server/routes/webhook.ts (handler body)
+import { onWebhook, receiveWebhook } from '@tolgee/apps-sdk/server';
+import { store } from '../activityStore';
+import { WEBHOOK_SECRET } from '../config';
+
+// inside the POST /webhook handler, after reading the raw body:
+const result = await receiveWebhook({
+  rawBody: raw,
+  signatureHeader: req.header('Tolgee-Signature'),
+  secret: WEBHOOK_SECRET,
+});
+if (!result.ok) return res.status(result.status).json({ error: result.error });
+
+onWebhook(result.payload, 'SET_TRANSLATIONS', (typed) => {
+  const occurredAt = new Date(typed.activityData?.timestamp ?? Date.now()).toISOString();
+  for (const t of typed.activityData?.modifiedEntities?.Translation ?? []) {
+    if (typeof t.entityId === 'number') store.record(t.entityId, occurredAt);
+  }
+});
+res.status(204).end();
+```
+
+`receiveWebhook` verifies the `Tolgee-Signature` over the raw body and parses a typed payload;
+`onWebhook` narrows it to the `SET_TRANSLATIONS` shape. Each modified `Translation` carries its
+`entityId` (the translation id) and `activityData.timestamp`.
+
+## 3. Serve the data to the iframe
+
+Add a small read endpoint the panel can call:
+
+```ts
+// server/routes/state.ts
+import type { Express, Request, Response } from 'express';
+import { store } from '../activityStore';
+
+export const registerStateRoute = (app: Express): void => {
+  app.get('/api/state', (req: Request, res: Response) => {
+    const ids = String(req.query.ids ?? '')
+      .split(',')
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+    res.json({ events: store.forIds(ids) });
+  });
+};
+```
+
+Register it in `server/index.ts` alongside the generated routes.
+
+## 4. Decorate rows (count badge)
+
+Edit the generated `server/routes/decorators.ts` to return a badge for the `translation-action` you
+declared. Tolgee POSTs the keys/languages in view; you return one item per cell to decorate:
+
+```ts
+// server/routes/decorators.ts
+const handleDecorators = (req, res) => {
+  const { keyIds = [], languageTags = [] } = req.body ?? {};
+  const items = [];
+  for (const keyId of keyIds) {
+    for (const tag of languageTags) {
+      // count = recent edits you have for that cell (demo uses a synthetic value)
+      const count = recentEditCount(keyId, tag);
+      items.push({
+        keyId,
+        languageTag: tag,
+        actionKey: 'show-activity',           // matches your translation-action key
+        count,
+        visibility: count === 0 ? 'on-hover' : 'always',
+      });
+    }
+  }
+  res.json({ items });
+};
+```
+
+The `icon`/`tooltip` come from the manifest action; the response references it by `actionKey` and
+sets the `count` badge and `visibility`. Make sure the action in `manifest.template.json` is
+`"dynamic": true` so Tolgee queries your decorators endpoint.
+
+## 5. Show the sparkline (panel)
+
+The panel iframe subscribes to the focused cell and fetches its activity:
+
+```tsx
+// src/modules/toolsPanel/index.tsx
+import { useEffect, useState } from 'react';
+import { createTolgeeApp, type TolgeeAppSelection } from '@tolgee/apps-sdk/browser';
+
+export default function ToolsPanel() {
+  const [selection, setSelection] = useState<TolgeeAppSelection>({});
+  const [buckets, setBuckets] = useState<number[]>([]);
+
+  useEffect(() => {
+    const app = createTolgeeApp();
+    app.context.then((ctx) => setSelection(ctx.selection));
+    return app.onSelectionChanged(setSelection);
+  }, []);
+
+  useEffect(() => {
+    if (selection.translationId == null) return;
+    fetch(`/api/state?ids=${selection.translationId}`)
+      .then((r) => r.json())
+      .then((data) => setBuckets(bucketByDay(data.events[selection.translationId!] ?? [], 14)));
+  }, [selection.translationId]);
+
+  return (
+    <div style={{ display: 'flex', gap: 2, alignItems: 'flex-end', height: 40 }}>
+      {buckets.map((n, i) => (
+        <div key={i} style={{ width: 6, height: Math.max(2, n * 8), background: '#3b82f6' }} />
+      ))}
+    </div>
+  );
+}
+
+// group ISO timestamps into N day-buckets (most recent last)
+function bucketByDay(times: string[], days: number): number[] {
+  const out = new Array(days).fill(0);
+  const dayMs = 86_400_000;
+  const now = Date.now();
+  for (const iso of times) {
+    const age = Math.floor((now - Date.parse(iso)) / dayMs);
+    if (age >= 0 && age < days) out[days - 1 - age]++;
+  }
+  return out;
+}
+```
+
+`createTolgeeApp().onSelectionChanged` fires whenever the user focuses a different cell. Call
+`app.resize(height)` if your panel content grows.
+
+## 6. Run and try it
+
+```bash
+# terminal 1
+npm run dev
+# terminal 2
+npm run register
+```
+
+Enable **activity-monitor** on a project, edit a translation, then focus that cell — the webhook
+records the edit, the decorator shows a count badge, and the panel renders the sparkline.
+
+:::tip
+Webhooks only fire for projects where the app is **enabled**, and only for the events your manifest
+subscribes to.
+:::
+
+## Full source
+
+This tutorial is based on the `dev-plugin` example app in the Tolgee platform repo
+(`apps/example-apps/dev-plugin`), which additionally persists activity to disk, prunes old events,
+adds a dashboard page and a key-edit audit tab, and serves emoji annotations. Use it as a complete
+reference.

--- a/tolgee-apps/tutorial-back-translation.mdx
+++ b/tolgee-apps/tutorial-back-translation.mdx
@@ -1,0 +1,250 @@
+---
+id: tutorial-back-translation
+title: "Tutorial: Back-translation QA app"
+sidebar_label: "Tutorial: Back-translation"
+description: Build a Tolgee App that uses an LLM to back-translate edits and flag semantic drift.
+---
+
+:::warning Experimental
+Tolgee Apps is in **alpha** — APIs may change.
+:::
+
+In this tutorial you'll build a quality-assurance app that, whenever a translation changes:
+
+1. **back-translates** it to the base language with an LLM,
+2. **compares** the back-translation to the original and assigns a verdict (`match` / `close` /
+   `mismatch`),
+3. **decorates** drifting cells with a warning/error icon, and
+4. shows the back-translation + verdict in a **panel**.
+
+It's a trimmed version of the [`back-translate`](https://github.com/tolgee/tolgee-platform) example —
+full source linked at the end. It uses the [Claude API](https://docs.claude.com); set
+`ANTHROPIC_API_KEY` in your server environment.
+
+## 1. Scaffold
+
+```bash
+npm create tolgee-app@alpha back-translate -- --yes \
+  --modules=translation-tools-panel,translation-action \
+  --scopes=translations.view,keys.view \
+  --webhooks=SET_TRANSLATIONS \
+  --tolgee-url=http://localhost:3000
+cd back-translate && npm install
+npm i @anthropic-ai/sdk
+```
+
+Edit `manifest.template.json` so the `translation-action` declares **two dynamic actions** — one for
+each severity — both opening the panel:
+
+```json
+"translation-action": [
+  { "key": "warning", "type": "panel", "panelKey": "panel", "dynamic": true,
+    "icon": "AlertCircle", "tooltip": "Back-translation drifts from base — review" },
+  { "key": "error", "type": "panel", "panelKey": "panel", "dynamic": true,
+    "icon": "AlertOctagon", "tooltip": "Back-translation differs from base — likely wrong" }
+]
+```
+
+## 2. The analyzer (LLM)
+
+```ts
+// server/backTranslation.ts
+import Anthropic from '@anthropic-ai/sdk';
+
+const client = process.env.ANTHROPIC_API_KEY
+  ? new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+  : null;
+
+export type Analysis = { backTranslation: string; verdict: 'match' | 'close' | 'mismatch'; explanation: string };
+
+const prompt = (baseLang: string, baseText: string, lang: string, text: string) =>
+  `You evaluate a translation by back-translating it and comparing semantically.
+
+Original (${baseLang}): "${baseText}"
+Translation (${lang}): "${text}"
+
+Steps:
+1. Translate the ${lang} text back to ${baseLang}.
+2. Compare to the original:
+   - "match"    — identical meaning
+   - "close"    — same intent, minor word-choice differences
+   - "mismatch" — different meaning
+
+Respond ONLY with valid JSON:
+{ "backTranslation": "...", "verdict": "match" | "close" | "mismatch", "explanation": "one short sentence" }`;
+
+export async function analyse(baseLang: string, baseText: string, lang: string, text: string): Promise<Analysis> {
+  if (!client) throw new Error('ANTHROPIC_API_KEY is not set');
+  const res = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 400,
+    messages: [{ role: 'user', content: prompt(baseLang, baseText, lang, text) }],
+  });
+  const raw = res.content[0]?.type === 'text' ? res.content[0].text : '';
+  const json = raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1);
+  return JSON.parse(json) as Analysis;
+}
+```
+
+A tiny store keyed by `(keyId, languageTag)` holds the latest verdict:
+
+```ts
+// server/analysisStore.ts
+import type { Analysis } from './backTranslation';
+const cache = new Map<string, Analysis & { text: string }>();
+const k = (keyId: number, tag: string) => `${keyId}:${tag}`;
+export const store = {
+  get: (keyId: number, tag: string) => cache.get(k(keyId, tag)),
+  set: (keyId: number, tag: string, a: Analysis & { text: string }) => cache.set(k(keyId, tag), a),
+};
+```
+
+## 3. Webhook → analyze in the background
+
+Translation analysis is slow (an LLM call), so acknowledge the webhook immediately and do the work
+after. In the generated `server/routes/webhook.ts` handler:
+
+```ts
+import { onWebhook, receiveWebhook } from '@tolgee/apps-sdk/server';
+
+const result = await receiveWebhook({ rawBody: raw, signatureHeader: req.header('Tolgee-Signature'), secret: WEBHOOK_SECRET });
+if (!result.ok) return res.status(result.status).json({ error: result.error });
+
+onWebhook(result.payload, 'SET_TRANSLATIONS', (typed) => {
+  void analyseModifiedTranslations(typed).catch((e) => console.error('analysis failed', e));
+});
+res.status(204).end();   // ack now; analysis runs async
+```
+
+`analyseModifiedTranslations` uses the context to read the base text, skips base-language edits, and
+stores a verdict per derived-language cell. To read translations it calls the Tolgee REST API with a
+[Personal Access Token or the app's credentials](./api#rest-endpoints) — see the full example for the
+`tolgeeApi` helper. The core loop:
+
+```ts
+for (const m of modified) {
+  if (m.languageTag === baseLang) continue;                 // base edit: nothing to back-translate
+  const { baseText, text } = await fetchPair(projectId, m.keyId, baseLang, m.languageTag);
+  const analysis = await analyse(baseLang, baseText, m.languageTag, text);
+  store.set(m.keyId, m.languageTag, { ...analysis, text });
+}
+```
+
+## 4. Decorate drifting cells
+
+Map the stored verdict to one of the two manifest actions; clean matches get no decorator:
+
+```ts
+// server/routes/decorators.ts
+const handleDecorators = (req, res) => {
+  const { keyIds = [], languageTags = [] } = req.body ?? {};
+  const items = [];
+  for (const keyId of keyIds) {
+    for (const tag of languageTags) {
+      const cached = store.get(keyId, tag);
+      if (!cached || cached.verdict === 'match') continue;
+      items.push({ keyId, languageTag: tag, actionKey: cached.verdict === 'close' ? 'warning' : 'error' });
+    }
+  }
+  res.json({ items });
+};
+```
+
+## 5. On-demand endpoint for the panel
+
+When the user focuses a cell, the panel asks for the analysis (reusing the cached webhook result):
+
+```ts
+// server/routes/translateBack.ts
+app.post('/translate-back', express.json(), async (req, res) => {
+  const { keyId, languageTag, baseLang, baseText, text } = req.body;
+  const cached = store.get(keyId, languageTag);
+  if (cached && cached.text === text) return res.json({ ...cached, cached: true });
+  const analysis = await analyse(baseLang, baseText, languageTag, text);
+  store.set(keyId, languageTag, { ...analysis, text });
+  res.json(analysis);
+});
+```
+
+## 6. The panel
+
+```tsx
+// src/modules/toolsPanel/index.tsx
+import { useEffect, useState } from 'react';
+import { createTolgeeApp, createTolgeeAppClient, type TolgeeAppContext, type TolgeeAppSelection } from '@tolgee/apps-sdk/browser';
+
+export default function ToolsPanel() {
+  const [ctx, setCtx] = useState<TolgeeAppContext | null>(null);
+  const [sel, setSel] = useState<TolgeeAppSelection>({});
+  const [baseLang, setBaseLang] = useState<string | null>(null);
+  const [analysis, setAnalysis] = useState<{ backTranslation: string; verdict: string; explanation: string } | null>(null);
+
+  useEffect(() => {
+    const app = createTolgeeApp();
+    app.context.then(setCtx);
+    return app.onSelectionChanged(setSel);
+  }, []);
+
+  // discover the project's base language
+  useEffect(() => {
+    if (!ctx) return;
+    createTolgeeAppClient(ctx)
+      .GET('/v2/projects/{projectId}', { params: { path: { projectId: ctx.projectId } } })
+      .then(({ data }) => setBaseLang(data?.baseLanguage?.tag ?? null));
+  }, [ctx]);
+
+  // on a non-base cell, fetch the pair and ask the server
+  useEffect(() => {
+    if (!ctx || !baseLang || !sel.keyId || !sel.languageTag || sel.languageTag === baseLang) return;
+    createTolgeeAppClient(ctx)
+      .GET('/v2/projects/{projectId}/translations', {
+        params: { path: { projectId: ctx.projectId }, query: { filterKeyId: [sel.keyId], languages: [baseLang, sel.languageTag], size: 1 } },
+      })
+      .then(({ data }) => {
+        const row = data?._embedded?.keys?.[0];
+        return fetch('/translate-back', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            keyId: sel.keyId, languageTag: sel.languageTag, baseLang,
+            baseText: row?.translations?.[baseLang]?.text,
+            text: row?.translations?.[sel.languageTag!]?.text,
+          }),
+        }).then((r) => r.json());
+      })
+      .then(setAnalysis);
+  }, [ctx, baseLang, sel.keyId, sel.languageTag]);
+
+  if (!analysis) return <p>Select a translation cell…</p>;
+  return (
+    <div>
+      <p><strong>Back-translation:</strong> {analysis.backTranslation}</p>
+      <p><strong>Verdict:</strong> {analysis.verdict} — {analysis.explanation}</p>
+    </div>
+  );
+}
+```
+
+## 7. Run
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+# terminal 1
+npm run dev
+# terminal 2
+npm run register
+```
+
+Enable the app on a project, edit a non-base-language translation, and watch the cell get a
+warning/error icon when the back-translation drifts — open the panel to see why.
+
+:::info Base-language edits
+When the **base** text changes, every derived translation for that key may become stale. The full
+example invalidates the cached analyses for the key so they're re-checked on next edit/focus.
+:::
+
+## Full source
+
+Based on the `back-translate` example app (`apps/example-apps/back-translate`), which adds proper
+base-language detection and invalidation, caching indicators in the panel, and a `tolgeeApi` helper
+for server-side REST calls. Use it as the complete reference.

--- a/tolgee-apps/tutorial-back-translation.mdx
+++ b/tolgee-apps/tutorial-back-translation.mdx
@@ -5,6 +5,11 @@ sidebar_label: "Tutorial: Back-translation"
 description: Build a Tolgee App that uses an LLM to back-translate edits and flag semantic drift.
 ---
 
+This tutorial builds a Tolgee App that checks translation quality with an LLM. When a translation
+changes, a webhook triggers a back-translation to the base language, compares the meaning, and assigns
+a verdict. Drifting cells get a warning or error decorator, and a panel explains the verdict. You
+scaffold it with `create-tolgee-app` and the Claude API. Tolgee Apps is alpha.
+
 :::warning Experimental
 Tolgee Apps is in **alpha** — APIs may change.
 :::


### PR DESCRIPTION
Adds a new top-level **Apps** documentation section for the (alpha) Tolgee Apps plugin platform.

## Pages
- **Introduction & architecture** — what apps are, the install → enable → iframe → REST → webhooks → decorators flow, module-types table, alpha limitations.
- **Setup & quickstart** — `create-tolgee-app`, the dev tunnel + browser register flow, enabling on a project, local-dev notes.
- **API reference** — manifest schema, `@tolgee/apps-sdk` browser/server, postMessage protocol, context token, webhook signature, decorators contract, scopes, REST endpoints, the `tolgee-app` CLI.
- **Tutorial: activity monitoring app** — webhooks → store → count decorator → activity sparkline panel.
- **Tutorial: back-translation QA app** — LLM back-translation on webhook, verdict store, warning/error decorators, on-demand panel.

Wired into `docs.js`, `navbar.js`, and a new `sidebarTolgeeApps.js`. `npm run build` passes (no broken links/anchors).

## ⚠️ Do not merge yet
The Tolgee Apps platform is **unmerged/alpha** (packages published under the npm \`alpha\` tag). Every page carries an experimental callout. This PR should stay **draft** and only merge once the apps feature ships.

## Known follow-ups (not blocking this PR)
- The SDK \`DecoratorItem\` type doesn't match the real webapp decorator contract; docs describe the real one — SDK type to be reconciled separately.
- Screenshots are TODO (text-only for now).