### PR TITLE
chore: fix table formatting in mcp docs

### DIFF
--- a/platform/integrations/mcp_server/about.mdx
+++ b/platform/integrations/mcp_server/about.mdx
@@ -45,6 +45,7 @@ All three talk to the same underlying Tolgee API but target different workflows.
 | **Discoverability** | High (AI lists tools and prompts for missing params) | Medium (use `tolgee --help`) | Low (read the OpenAPI spec) |
 | **Determinism** | Lower — natural language can be ambiguous | High | High |
 | **Bulk / batch ops** | ✔ | ✔ | ✔ |
+
 A common end-state of our users:
 
 - **MCP server** — day-to-day exploratory work and one-off fixes from inside Claude or Cursor.


### PR DESCRIPTION
Currently, it is shown like this:

<img width="1339" height="337" alt="Screenshot 2026-06-16 at 9 41 55" src="https://github.com/user-attachments/assets/255bb771-fea7-47b9-b9e9-00fa2606a918" />
