### PR TITLE
Fix port of postgres in Docker containers

### DIFF
--- a/platform/self_hosting/running_with_docker.mdx
+++ b/platform/self_hosting/running_with_docker.mdx
@@ -38,7 +38,7 @@ services:
       - ./data:/data
       - ./config.yaml:/config.yaml
     ports:
-      - '25432:25432' # if you would like to access the DB
+      - '25432:5432' # if you would like to access the DB
       - '8080:8080'
     environment:
       spring.config.additional-location: file:///config.yaml
@@ -63,7 +63,7 @@ services:
     volumes:
       - ./data:/data
     ports:
-      - '25432:25432'
+      - '25432:5432'
       - '8080:8080'
     env_file:
       - .env


### PR DESCRIPTION
I have:

```sh
/ # netstat -lnt
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State
tcp        0      0 127.0.0.11:33991        0.0.0.0:*               LISTEN
tcp        0      0 0.0.0.0:5432            0.0.0.0:*               LISTEN
tcp        0      0 :::8080                 :::*                    LISTEN
tcp        0      0 :::5432                 :::*                    LISTEN
```

So, postgresql is listening to port 5432, not 25432...