### PR TITLE
docs: correct MT provider list and AI Translator context availability

### DIFF
--- a/platform/translation_process/ai_translator.mdx
+++ b/platform/translation_process/ai_translator.mdx
@@ -17,7 +17,7 @@ Azure OpenAI, Anthropic Claude, Google AI (Gemini), or any OpenAI-compatible API
 ## AI Translator with context
 
 :::info
-This functionality is available only in the Cloud version with SDK 5.9.0 and higher.
+This functionality requires Tolgee SDK 5.9.0 or higher.
 :::
 
 Tolgee Context is a statistic about relations between the keys based on how they are laid out in your application.

--- a/platform/translation_process/machine_translation.mdx
+++ b/platform/translation_process/machine_translation.mdx
@@ -24,6 +24,7 @@ Currently, we support the following machine translation providers:
 - Amazon Translate (AWS)
 - DeepL
 - Microsoft Azure Translator
+- Baidu Translate (self-hosted only, configured with your own API key)
 - [AI Translator](ai_translator)
 
 ## Context for machine translations


### PR DESCRIPTION
Two statements in the docs do not match the product. Both were found while verifying Tolgee feature availability against the platform source for a comparison page.

## Machine translation providers

`platform/translation_process/machine_translation.mdx` listed four external providers. The product ships five: `MtServiceType` has `GOOGLE`, `AWS`, `DEEPL`, `AZURE` and `BAIDU`, and Baidu Translate has its own configuration section in the self-hosting docs (`tolgee.machine-translation.baidu`).

Added Baidu, marked self-hosted only since it is configured with your own API key via server configuration.

## AI Translator context

`platform/translation_process/ai_translator.mdx` said Tolgee Context is "available only in the Cloud version with SDK 5.9.0 and higher". It is not Cloud only. The SDK 5.9.0 requirement is the real constraint, so the note now states just that.

## Why this matters

Both statements understate what Tolgee does, and a competitor comparison page repeated one of them because our own docs said it. The provider count in particular was used to score a competitor claim as wrong when the competitor was right.

## Not covered here

Three further inaccuracies live on `tolgee.io/pricing`, which is not in this repo:

- The AI translator is marked N/A on the Free plan. No such gate exists in the code; `LlmProviderController` has no `@RequiresFeatures` and there is no AI translator feature in the `Feature` enum.
- Included MT credits for Team and Advanced disagree with the billing API (10,000 vs 200,000, and 1,000,000 vs 2,000,000).
- The Advanced extra-seat price disagrees with the billing API (EUR 22 vs 16).