### PR TITLE
chore: stop Dependabot from proposing major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     schedule:
       interval: monthly
     target-branch: main
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    # Splitting this group breaks every API reference page in the browser while
+    # the build and the deploy preview still pass.
+    groups:
+      openapi-docs:
+        patterns:
+          - "docusaurus-plugin-openapi-docs"
+          - "docusaurus-theme-openapi-docs"


### PR DESCRIPTION
## What changed

Two things in `.github/dependabot.yml`:

- Ignore major bumps for everything.
- Group the openapi-docs plugin and theme so they can only be bumped together.

Patch and minor updates keep coming as before.

## Why

Every major bump Dependabot opened in this repo needed a migration it cannot do on its own:

- Tailwind 4 moves the PostCSS plugin to a separate package and needs a config rewrite.
- ESLint 10 needs the flat config format.
- React 19 is not supported by Docusaurus 3.
- Bumping `@docusaurus/core` alone leaves the other `@docusaurus/*` packages behind, so the build breaks.

They all failed CI, got closed, and came back the next month. There are 4 closed react-dom branches and 3 for eslint. Doing a major by hand, when there is a reason to, is the only way these land.

The grouping rule fixes a worse problem. The openapi-docs plugin and theme must share a version. Bumping only the plugin (#1103, #1122) breaks every API reference page in the browser, and neither the build nor the deploy preview catches it, because the failure is client side.

## On security updates

An `ignore` rule also applies to Dependabot security update PRs, so a wildcard would normally be too blunt. It is fine here: Dependabot security updates and Dependabot alerts are both switched off for this repository, so there is nothing for the rule to suppress. If either is turned on later, this rule should become a list of package names instead.